### PR TITLE
docs: add README (2/18)

### DIFF
--- a/AoxiangAssistant/README.md
+++ b/AoxiangAssistant/README.md
@@ -1,0 +1,46 @@
+# 翱翔教务助手 (HarmonyOS)
+
+西北工业大学教务系统助手，HarmonyOS (ArkTS) 原生客户端。
+
+## 功能
+
+- **成绩查询** — 自动采集全部课程成绩，计算加权 GPA 和加权平均分
+- **电费查询** — 实时查询宿舍电费余额
+- **课表导入** — 自动导入课程表（开发中）
+
+## 技术实现
+
+- 通过 WebView 自动化模拟 SSO 统一身份认证登录
+- `auto_collect.js` 状态机驱动页面导航和数据提取
+- HUKS AES-256-GCM 加密安全存储用户凭证
+- 成绩与电费数据持久化到 Preferences
+
+## 构建
+
+使用 DevEco Studio 打开 `AoxiangAssistant` 目录，连接 HarmonyOS 设备或模拟器后直接运行。
+
+- 最低 API 版本：12
+- 目标 SDK：API 24 (HarmonyOS 6.1.1)
+- ArkTS 严格模式
+
+## 项目结构
+
+```
+AoxiangAssistant/
+├── entry/src/main/
+│   ├── ets/
+│   │   ├── pages/Index.ets          # 主页面（Tab 导航 + WebView 自动化）
+│   │   ├── model/
+│   │   │   ├── CredentialStore.ets  # HUKS 加密凭证存储
+│   │   │   └── GradeModel.ets       # 成绩数据模型与加权计算
+│   │   └── common/Constants.ets     # SSO URL 与状态常量
+│   ├── resources/rawfile/
+│   │   └── auto_collect.js          # WebView JS 自动化脚本
+│   └── module.json5                 # 模块配置与权限声明
+├── AppScope/app.json5
+└── build-profile.json5
+```
+
+## 原安卓版
+
+安卓原版代码位于 `aoxiang-assistant/`（未纳入本仓库版本管理）。


### PR DESCRIPTION
## 原始提交

- 原始 commit: `ef54b4be09e4b6a6d6d154cc077acab34a224b40`
- 本 PR commit: `59b464158d8b9377ae456cba5780a019f6465900`
- 提交序号: 2/18
- 原作者与作者时间已保留；提交者为 `Chenqi1999 <lorcas.zephyr@gmail.com>`
- 本 PR 基于已合入的 PR 1，目标分支为 `Lorcas-Zephyr/aoxiang-assistant:harmony`

## 完成内容

- 新增 `AoxiangAssistant/README.md`，补充 HarmonyOS 版项目说明。
- 说明成绩查询、电费查询、课表导入等当前功能范围。
- 记录 WebView SSO、`auto_collect.js`、HUKS AES-256-GCM 和 Preferences 等技术实现。
- 补充 DevEco Studio 构建方式、最低 API、目标 SDK 和 ArkTS 严格模式信息。
- 补充 HarmonyOS 工程目录结构和原安卓版说明。

## 验证

- 相对上游当前 `harmony`，本 PR 仅包含 `AoxiangAssistant/README.md` 的新增。
- GitHub 分支仅包含 1 个 commit。
- 文档内容与原始 commit `ef54b4b` 完全一致。