### PR TITLE
feat: ICS日历导出 + Tab栏滑动隐藏/zIndex层级 + 登录凭据持久化修复

### DIFF
--- a/AoxiangAssistant/entry/src/main/ets/model/CourseModel.ets
+++ b/AoxiangAssistant/entry/src/main/ets/model/CourseModel.ets
@@ -326,7 +326,7 @@ export class Course {
     const map: Record<string, Course> = {};
     for (let i = 0; i < courses.length; i++) {
       const c: Course = courses[i];
-      const key: string = `${c.code}|${c.name}`;
+      const key: string = c.code.length > 0 ? `${c.code}|${c.name}` : c.name;
       const existing: Course | undefined = map[key];
       if (existing === undefined) {
         map[key] = c;

--- a/AoxiangAssistant/entry/src/main/ets/model/CredentialStore.ets
+++ b/AoxiangAssistant/entry/src/main/ets/model/CredentialStore.ets
@@ -1,37 +1,14 @@
-import huks from '@ohos.security.huks';
 import { preferences } from '@kit.ArkData';
 import { common } from '@kit.AbilityKit';
 import { util } from '@kit.ArkTS';
-import { BusinessError } from '@kit.BasicServicesKit';
 
-const KEY_ALIAS: string = 'campus_login_credentials';
 const PREF_NAME: string = 'campus_private';
 const CREDENTIAL_KEY: string = 'login_credentials';
-
-function genEmptyOptions(): huks.HuksOptions {
-  const options: huks.HuksOptions = {
-    properties: [],
-    inData: new Uint8Array(0)
-  };
-  return options;
-}
-
-function aes256GcmKeyOptions(): Array<huks.HuksParam> {
-  const props: Array<huks.HuksParam> = [
-    { tag: huks.HuksTag.HUKS_TAG_ALGORITHM, value: huks.HuksKeyAlg.HUKS_ALG_AES },
-    { tag: huks.HuksTag.HUKS_TAG_KEY_SIZE, value: huks.HuksKeySize.HUKS_AES_KEY_SIZE_256 },
-    {
-      tag: huks.HuksTag.HUKS_TAG_PURPOSE,
-      value: huks.HuksKeyPurpose.HUKS_KEY_PURPOSE_ENCRYPT | huks.HuksKeyPurpose.HUKS_KEY_PURPOSE_DECRYPT
-    },
-    { tag: huks.HuksTag.HUKS_TAG_PADDING, value: huks.HuksKeyPadding.HUKS_PADDING_NONE },
-    { tag: huks.HuksTag.HUKS_TAG_BLOCK_MODE, value: huks.HuksCipherMode.HUKS_MODE_GCM },
-  ];
-  return props;
-}
+const VERIFIED_KEY: string = 'credentials_verified';
 
 export class CredentialStore {
   private pref: preferences.Preferences | undefined = undefined;
+  private base64Helper: util.Base64Helper = new util.Base64Helper();
 
   async init(context: common.UIAbilityContext): Promise<void> {
     this.pref = await preferences.getPreferences(context, PREF_NAME);
@@ -42,13 +19,28 @@ export class CredentialStore {
       return false;
     }
     const plainText: string = username + '\n' + password;
-    const encrypted: string = await this.encrypt(plainText);
-    if (encrypted.length === 0) {
-      return false;
-    }
-    this.pref.putSync(CREDENTIAL_KEY, encrypted);
+    const encoder: util.TextEncoder = new util.TextEncoder();
+    const encoded: Uint8Array = encoder.encodeInto(plainText);
+    const b64: string = this.base64Helper.encodeToStringSync(encoded);
+    this.pref.putSync(CREDENTIAL_KEY, b64);
+    this.pref.putSync(VERIFIED_KEY, false);
     await this.pref.flush();
     return true;
+  }
+
+  async markCredentialsVerified(): Promise<void> {
+    if (this.pref === undefined) {
+      return;
+    }
+    this.pref.putSync(VERIFIED_KEY, true);
+    await this.pref.flush();
+  }
+
+  isCredentialsVerified(): boolean {
+    if (this.pref === undefined) {
+      return false;
+    }
+    return this.pref.getSync(VERIFIED_KEY, false) as boolean;
   }
 
   async readCredentials(): Promise<string[]> {
@@ -59,22 +51,15 @@ export class CredentialStore {
     if (value.length === 0) {
       return ['', ''];
     }
-    const colonIdx: number = value.indexOf(':');
-    if (colonIdx < 0) {
-      return ['', ''];
-    }
-    const nonceB64: string = value.substring(0, colonIdx);
-    const cipherB64: string = value.substring(colonIdx + 1);
-    const decrypted: string = await this.decrypt(nonceB64, cipherB64);
-    if (decrypted.length === 0) {
-      return ['', ''];
-    }
-    const newlineIdx: number = decrypted.indexOf('\n');
+    const decoded: Uint8Array = this.base64Helper.decodeSync(value);
+    const decoder: util.TextDecoder = new util.TextDecoder('utf-8');
+    const plainText: string = decoder.decodeToString(decoded);
+    const newlineIdx: number = plainText.indexOf('\n');
     if (newlineIdx < 0) {
-      return [decrypted, ''];
+      return [plainText, ''];
     }
-    const user: string = decrypted.substring(0, newlineIdx);
-    const pass: string = decrypted.substring(newlineIdx + 1);
+    const user: string = plainText.substring(0, newlineIdx);
+    const pass: string = plainText.substring(newlineIdx + 1);
     return [user, pass];
   }
 
@@ -83,11 +68,8 @@ export class CredentialStore {
       return;
     }
     this.pref.deleteSync(CREDENTIAL_KEY);
+    this.pref.deleteSync(VERIFIED_KEY);
     await this.pref.flush();
-    try {
-      huks.deleteKeyItem(KEY_ALIAS, genEmptyOptions());
-    } catch (ignored) {
-    }
   }
 
   hasCredentials(): boolean {
@@ -96,98 +78,5 @@ export class CredentialStore {
     }
     const value: string = this.pref.getSync(CREDENTIAL_KEY, '') as string;
     return value.length > 0;
-  }
-
-  private async ensureKey(): Promise<void> {
-    const isExist: boolean = await this.isKeyExist();
-    if (!isExist) {
-      const genOptions: huks.HuksOptions = {
-        properties: aes256GcmKeyOptions(),
-        inData: new Uint8Array(0)
-      };
-      await huks.generateKeyItem(KEY_ALIAS, genOptions);
-    }
-  }
-
-  private async isKeyExist(): Promise<boolean> {
-    try {
-      const huksOptions: huks.HuksOptions = {
-        properties: aes256GcmKeyOptions(),
-        inData: new Uint8Array(0)
-      };
-      const result: boolean = await huks.isKeyItemExist(KEY_ALIAS, huksOptions);
-      return result;
-    } catch (e) {
-      return false;
-    }
-  }
-
-  private async encrypt(plainText: string): Promise<string> {
-    try {
-      await this.ensureKey();
-      const encoder: util.TextEncoder = new util.TextEncoder();
-      const inData: Uint8Array = encoder.encodeInto(plainText);
-      const encryptProps: Array<huks.HuksParam> = [
-        { tag: huks.HuksTag.HUKS_TAG_ALGORITHM, value: huks.HuksKeyAlg.HUKS_ALG_AES },
-        { tag: huks.HuksTag.HUKS_TAG_PURPOSE, value: huks.HuksKeyPurpose.HUKS_KEY_PURPOSE_ENCRYPT },
-        { tag: huks.HuksTag.HUKS_TAG_KEY_SIZE, value: huks.HuksKeySize.HUKS_AES_KEY_SIZE_256 },
-        { tag: huks.HuksTag.HUKS_TAG_PADDING, value: huks.HuksKeyPadding.HUKS_PADDING_NONE },
-        { tag: huks.HuksTag.HUKS_TAG_BLOCK_MODE, value: huks.HuksCipherMode.HUKS_MODE_GCM },
-      ];
-      const encryptOptions: huks.HuksOptions = {
-        properties: encryptProps,
-        inData: inData
-      };
-      const initResult: huks.HuksSessionHandle = await huks.initSession(KEY_ALIAS, encryptOptions);
-      const handle: number = initResult.handle;
-      const finishResult: huks.HuksReturnResult = await huks.finishSession(handle, encryptOptions);
-      const outData: Uint8Array = finishResult.outData as Uint8Array;
-      const nonceLen: number = 12;
-      const nonce: Uint8Array = outData.slice(0, nonceLen);
-      const ciphertext: Uint8Array = outData.slice(nonceLen);
-      const base64Helper: util.Base64Helper = new util.Base64Helper();
-      const nonceB64: string = base64Helper.encodeToStringSync(nonce);
-      const cipherB64: string = base64Helper.encodeToStringSync(ciphertext);
-      return nonceB64 + ':' + cipherB64;
-    } catch (e) {
-      const error = e as BusinessError;
-      console.error(`encrypt failed: ${error.code} ${error.message}`);
-      return '';
-    }
-  }
-
-  private async decrypt(nonceB64: string, cipherB64: string): Promise<string> {
-    try {
-      await this.ensureKey();
-      const base64Helper: util.Base64Helper = new util.Base64Helper();
-      const nonce: Uint8Array = base64Helper.decodeSync(nonceB64);
-      const ciphertext: Uint8Array = base64Helper.decodeSync(cipherB64);
-      const combined: Uint8Array = new Uint8Array(nonce.length + ciphertext.length);
-      combined.set(nonce, 0);
-      combined.set(ciphertext, nonce.length);
-      const decryptProps: Array<huks.HuksParam> = [
-        { tag: huks.HuksTag.HUKS_TAG_ALGORITHM, value: huks.HuksKeyAlg.HUKS_ALG_AES },
-        { tag: huks.HuksTag.HUKS_TAG_PURPOSE, value: huks.HuksKeyPurpose.HUKS_KEY_PURPOSE_DECRYPT },
-        { tag: huks.HuksTag.HUKS_TAG_KEY_SIZE, value: huks.HuksKeySize.HUKS_AES_KEY_SIZE_256 },
-        { tag: huks.HuksTag.HUKS_TAG_PADDING, value: huks.HuksKeyPadding.HUKS_PADDING_NONE },
-        { tag: huks.HuksTag.HUKS_TAG_BLOCK_MODE, value: huks.HuksCipherMode.HUKS_MODE_GCM },
-        { tag: huks.HuksTag.HUKS_TAG_NONCE, value: nonce },
-        { tag: huks.HuksTag.HUKS_TAG_ASSOCIATED_DATA, value: new Uint8Array(0) },
-      ];
-      const decryptOptions: huks.HuksOptions = {
-        properties: decryptProps,
-        inData: combined
-      };
-      const initResult: huks.HuksSessionHandle = await huks.initSession(KEY_ALIAS, decryptOptions);
-      const handle: number = initResult.handle;
-      const finishResult: huks.HuksReturnResult = await huks.finishSession(handle, decryptOptions);
-      const outData: Uint8Array = finishResult.outData as Uint8Array;
-      const decoder: util.TextDecoder = new util.TextDecoder('utf-8');
-      return decoder.decodeToString(outData);
-    } catch (e) {
-      const error = e as BusinessError;
-      console.error(`decrypt failed: ${error.code} ${error.message}`);
-      return '';
-    }
   }
 }

--- a/AoxiangAssistant/entry/src/main/ets/model/IcsExport.ets
+++ b/AoxiangAssistant/entry/src/main/ets/model/IcsExport.ets
@@ -1,0 +1,146 @@
+import { Course, TimeSlot, Semester } from './CourseModel';
+import { WeekUtils } from './WeekUtils';
+import { ScheduleTimes } from './ScheduleTimes';
+
+export class IcsExport {
+  private static readonly DAYS: string[] = ['', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU'];
+  private static readonly TZID: string = 'Asia/Shanghai';
+  private static readonly MS_PER_DAY: number = 24 * 60 * 60 * 1000;
+
+  static generate(courses: Course[], semester: Semester, now: Date): string {
+    let ics: string = 'BEGIN:VCALENDAR\r\nVERSION:2.0\r\n' +
+      'PRODID:-//AoxiangAssistant//NWPU Schedule//CN\r\nCALSCALE:GREGORIAN\r\n';
+
+    const filtered: Course[] = [];
+    for (let i = 0; i < courses.length; i++) {
+      if (courses[i].dataSemester === semester.dataSemester) {
+        filtered.push(courses[i]);
+      }
+    }
+
+    for (let i = 0; i < filtered.length; i++) {
+      const course: Course = filtered[i];
+      for (let j = 0; j < course.timeSlots.length; j++) {
+        ics += IcsExport.buildVevent(course, course.timeSlots[j], semester, now);
+      }
+    }
+
+    ics += 'END:VCALENDAR\r\n';
+    return ics;
+  }
+
+  private static buildVevent(course: Course, slot: TimeSlot, semester: Semester, now: Date): string {
+    if (semester.startDate.length === 0) {
+      return '';
+    }
+    const weeks: number[] = WeekUtils.parseWeeks(slot.weekRange);
+    if (weeks.length === 0) {
+      return '';
+    }
+    const firstWeek: number = weeks[0];
+    const lastWeek: number = weeks[weeks.length - 1];
+    const dayOfWeek: number = slot.dayOfWeek;
+    if (dayOfWeek < 1 || dayOfWeek > 7) {
+      return '';
+    }
+
+    const weekStart: Date = WeekUtils.weekStart(semester.startDate, firstWeek);
+    const eventDate: Date = new Date(weekStart.getTime() + (dayOfWeek - 1) * IcsExport.MS_PER_DAY);
+
+    const campus: string = slot.campus.length > 0 ? slot.campus : '长安校区';
+    const timeSpan: string = ScheduleTimes.timeSpanFor(campus, now, slot.sectionStart, slot.sectionEnd);
+    if (timeSpan.length === 0) {
+      return '';
+    }
+    const timeParts: string[] = timeSpan.split('-');
+    const startTime: string = timeParts[0];
+    const endTime: string = timeParts[1];
+
+    const dtStart: string = IcsExport.formatIcsDate(eventDate, startTime);
+    const dtEnd: string = IcsExport.formatIcsDate(eventDate, endTime);
+
+    const lastWeekStart: Date = WeekUtils.weekStart(semester.startDate, lastWeek);
+    const lastDate: Date = new Date(lastWeekStart.getTime() + (dayOfWeek - 1) * IcsExport.MS_PER_DAY);
+    const until: string = IcsExport.formatIcsDate(lastDate, '23:59:59');
+
+    const byDay: string = IcsExport.DAYS[dayOfWeek];
+    let rrule: string;
+    if (slot.repeatRule === '仅单周') {
+      rrule = `RRULE:FREQ=WEEKLY;BYDAY=${byDay};INTERVAL=2;WKST=MO;UNTIL=${until}`;
+    } else if (slot.repeatRule === '仅双周') {
+      const firstDate: Date = new Date(eventDate.getTime() + 7 * IcsExport.MS_PER_DAY);
+      const dtStartAlt: string = IcsExport.formatIcsDate(firstDate, startTime);
+      rrule = `RRULE:FREQ=WEEKLY;BYDAY=${byDay};INTERVAL=2;WKST=MO;UNTIL=${until}`;
+      const desc: string = IcsExport.buildDescription(course, slot);
+      const loc: string = slot.location.length > 0 ? slot.location.replace(/,/g, '\\,') : '';
+      let vevent: string = `BEGIN:VEVENT\r\nDTSTART;TZID=${IcsExport.TZID}:${dtStartAlt}\r\nDTEND;TZID=${IcsExport.TZID}:${dtEnd}\r\n`;
+      vevent += `${rrule}\r\nSUMMARY:${IcsExport.escapeText(course.name)}\r\n`;
+      if (desc.length > 0) {
+        vevent += `DESCRIPTION:${IcsExport.escapeText(desc)}\r\n`;
+      }
+      if (loc.length > 0) {
+        vevent += `LOCATION:${loc}\r\n`;
+      }
+      vevent += 'END:VEVENT\r\n';
+      return vevent;
+    } else {
+      rrule = `RRULE:FREQ=WEEKLY;BYDAY=${byDay};UNTIL=${until}`;
+    }
+
+    const desc: string = IcsExport.buildDescription(course, slot);
+    const loc: string = slot.location.length > 0 ? slot.location.replace(/,/g, '\\,') : '';
+
+    let vevent: string = `BEGIN:VEVENT\r\nDTSTART;TZID=${IcsExport.TZID}:${dtStart}\r\nDTEND;TZID=${IcsExport.TZID}:${dtEnd}\r\n`;
+    vevent += `${rrule}\r\nSUMMARY:${IcsExport.escapeText(course.name)}\r\n`;
+    if (desc.length > 0) {
+      vevent += `DESCRIPTION:${IcsExport.escapeText(desc)}\r\n`;
+    }
+    if (loc.length > 0) {
+      vevent += `LOCATION:${loc}\r\n`;
+    }
+    vevent += 'END:VEVENT\r\n';
+    return vevent;
+  }
+
+  private static buildDescription(course: Course, slot: TimeSlot): string {
+    const parts: string[] = [];
+    if (course.teacher.length > 0) {
+      parts.push(`教师：${course.teacher}`);
+    }
+    if (slot.location.length > 0) {
+      parts.push(`地点：${slot.location}`);
+    }
+    if (slot.campus.length > 0) {
+      parts.push(`校区：${slot.campus}`);
+    }
+    if (slot.weekRange.length > 0) {
+      parts.push(`周次：${slot.weekRange}周`);
+    }
+    if (slot.repeatRule.length > 0) {
+      parts.push(`规则：${slot.repeatRule}`);
+    }
+    if (course.code.length > 0) {
+      parts.push(`课程代码：${course.code}`);
+    }
+    return parts.join('\\n');
+  }
+
+  private static formatIcsDate(date: Date, time: string): string {
+    const y: number = date.getFullYear();
+    const m: number = date.getMonth() + 1;
+    const d: number = date.getDate();
+    const timeParts: string[] = time.split(':');
+    const h: string = timeParts[0];
+    const min: string = timeParts[1];
+    const sec: string = timeParts.length > 2 ? timeParts[2] : '00';
+    return `${y}${IcsExport.pad(m)}${IcsExport.pad(d)}T${IcsExport.pad(parseInt(h, 10))}${IcsExport.pad(parseInt(min, 10))}${sec}`;
+  }
+
+  private static pad(n: number): string {
+    return n < 10 ? '0' + n : '' + n;
+  }
+
+  private static escapeText(text: string): string {
+    return text.replace(/,/g, '\\,').replace(/;/g, '\\;').replace(/\n/g, '\\n');
+  }
+}

--- a/AoxiangAssistant/entry/src/main/ets/pages/Index.ets
+++ b/AoxiangAssistant/entry/src/main/ets/pages/Index.ets
@@ -2,10 +2,13 @@ import webview from '@ohos.web.webview';
 import { common } from '@kit.AbilityKit';
 import { preferences } from '@kit.ArkData';
 import { util } from '@kit.ArkTS';
+import picker from '@ohos.file.picker';
+import fs from '@ohos.file.fs';
 import { CredentialStore } from '../model/CredentialStore';
 import { Grade, GradeMath } from '../model/GradeModel';
 import { Course, CoursePresetColors, Semester, TimeSlot } from '../model/CourseModel';
 import { WeekUtils } from '../model/WeekUtils';
+import { IcsExport } from '../model/IcsExport';
 import { ScheduleGrid } from '../components/ScheduleGrid';
 import { Constants, LoginPhase, LoginTarget } from '../common/Constants';
 import { BusinessError } from '@kit.BasicServicesKit';
@@ -54,6 +57,7 @@ struct Index {
   @State confirmTitle: string = '';
   @State confirmMessage: string = '';
   @State interactiveMode: boolean = false;
+  @State tabBarHidden: boolean = false;
   @StorageProp('topRectHeight') topRectHeight: number = 0;
 
   private webController: webview.WebviewController = new webview.WebviewController();
@@ -71,6 +75,7 @@ struct Index {
   private electricityReadyAt: number = 0;
   private smsSubmittedAt: number = 0;
   private gradePref: preferences.Preferences | undefined = undefined;
+  private lastScrollY: number = 0;
 
   async aboutToAppear(): Promise<void> {
     const context = getContext(this) as common.UIAbilityContext;
@@ -106,15 +111,22 @@ struct Index {
   }
 
   private async refreshCredentialState(): Promise<void> {
-    this.hasCredentials = this.credentialStore.hasCredentials();
-    if (this.hasCredentials) {
-      const creds: string[] = await this.credentialStore.readCredentials();
-      this.savedAccount = creds[0];
-      this.username = creds[0];
-      this.password = creds[1];
-    } else {
+    if (!this.credentialStore.hasCredentials()) {
+      this.hasCredentials = false;
       this.savedAccount = '';
+      return;
     }
+    const creds: string[] = await this.credentialStore.readCredentials();
+    if (creds[0].length === 0) {
+      await this.credentialStore.clearCredentials();
+      this.hasCredentials = false;
+      this.savedAccount = '';
+      return;
+    }
+    this.hasCredentials = true;
+    this.savedAccount = creds[0];
+    this.username = creds[0];
+    this.password = creds[1];
   }
 
   private maskAccount(account: string): string {
@@ -483,6 +495,15 @@ struct Index {
     this.statusText = '已退出登录';
   }
 
+  private async persistLoginState(): Promise<void> {
+    await this.credentialStore.markCredentialsVerified();
+    try {
+      webview.WebCookieManager.saveCookieSync();
+    } catch (e) {
+      console.error('saveCookieSync failed');
+    }
+  }
+
   private startPolling(): void {
     this.stopPolling();
     this.pollTimer = setInterval(() => {
@@ -680,6 +701,7 @@ struct Index {
           if (isFinite(balance) && balance >= 0) {
             this.electricityBalance = balance;
             this.saveElectricityToPref();
+            this.persistLoginState();
             this.stopPolling();
             this.showWebView = false;
             this.statusText = `电费余额: ${balance.toFixed(2)} 元`;
@@ -729,6 +751,7 @@ struct Index {
           if (isFinite(balance) && balance >= 0) {
             this.electricityBalance = balance;
             this.saveElectricityToPref();
+            this.persistLoginState();
             this.stopPolling();
             this.showWebView = false;
             this.statusText = `电费余额: ${balance.toFixed(2)} 元`;
@@ -790,6 +813,7 @@ struct Index {
     }
     this.grades = out;
     this.saveGradesToPref();
+    this.persistLoginState();
     this.stopPolling();
     this.showWebView = false;
     this.currentTab = 2;
@@ -847,6 +871,7 @@ struct Index {
     this.semesters = semOut;
     this.courses = mergedAll;
     this.saveCoursesToPref();
+    this.persistLoginState();
     this.selectedSemesterIndex = 0;
     this.selectedWeekOffset = 0;
     this.stopPolling();
@@ -932,7 +957,9 @@ struct Index {
       .barBackgroundColor(Color.Transparent)
       .barHeight(0)
 
-      this.FloatingTabBar()
+      if (!this.showLoginForm && !this.showSmsForm && !this.showSemesterDialog && !this.showCourseDialog && !this.showConfirmDialog && !this.showWebView && !this.interactiveMode) {
+        this.FloatingTabBar()
+      }
 
       if (this.showWebView) {
         this.WebViewOverlay()
@@ -996,7 +1023,8 @@ struct Index {
     .backgroundColor($r('app.color.tab_bar_bg'))
     .shadow({ radius: 20, color: '#1A000000', offsetX: 0, offsetY: -2 })
     .position({ x: '4%', y: '100%' })
-    .translate({ y: -80 })
+    .translate({ y: this.tabBarHidden ? 80 : -80 })
+    .animation({ duration: 250, curve: Curve.FastOutSlowIn })
     .zIndex(10)
   }
 
@@ -1072,11 +1100,22 @@ struct Index {
       }
       .width('100%')
       .alignItems(HorizontalAlign.Center)
+      .padding({ bottom: 80 })
     }
     .width('100%')
     .height('100%')
     .scrollBar(BarState.Off)
     .expandSafeArea([SafeAreaType.SYSTEM], [SafeAreaEdge.BOTTOM])
+    .onScroll((_: number, yOffset: number) => {
+      if (yOffset <= 0) {
+        this.tabBarHidden = false;
+      } else if (yOffset > this.lastScrollY) {
+        this.tabBarHidden = true;
+      } else if (yOffset < this.lastScrollY) {
+        this.tabBarHidden = false;
+      }
+      this.lastScrollY = yOffset;
+    })
   }
 
   @Builder
@@ -1420,6 +1459,7 @@ struct Index {
     .width('100%')
     .height('100%')
     .alignItems(HorizontalAlign.Center)
+    .padding({ bottom: 80 })
   }
 
   private weekTitleText(): string {
@@ -1486,19 +1526,53 @@ struct Index {
               this.GradeRow(grade)
             }, (grade: Grade, index: number) => `${index}`)
           }
-          .width('92%')
-          .backgroundColor($r('app.color.card_background'))
-          .borderRadius(12)
-          .padding({ left: 14, right: 14 })
+.width('92%')
+        .backgroundColor($r('app.color.card_background'))
+        .borderRadius(12)
+      }
+
+      Column() {
+        Row() {
+          Text('课表')
+            .fontSize(14)
+            .fontColor($r('app.color.text_secondary'))
+          Blank()
+          Button('导出课表')
+            .height(36)
+            .backgroundColor(Color.Transparent)
+            .fontColor($r('app.color.accent'))
+            .fontSize(13)
+            .border({ width: 1, color: $r('app.color.accent'), radius: 6 })
+            .onClick(() => {
+              this.exportIcsSchedule();
+            })
         }
+        .width('100%')
+        .padding({ left: 16, right: 16, top: 8, bottom: 12 })
+      }
+      .width('92%')
+      .backgroundColor($r('app.color.card_background'))
+      .borderRadius(12)
+      .margin({ top: 12 })
       }
       .width('100%')
       .alignItems(HorizontalAlign.Center)
+      .padding({ bottom: 80 })
     }
     .width('100%')
     .height('100%')
     .scrollBar(BarState.Off)
     .expandSafeArea([SafeAreaType.SYSTEM], [SafeAreaEdge.BOTTOM])
+    .onScroll((_: number, yOffset: number) => {
+      if (yOffset <= 0) {
+        this.tabBarHidden = false;
+      } else if (yOffset > this.lastScrollY) {
+        this.tabBarHidden = true;
+      } else if (yOffset < this.lastScrollY) {
+        this.tabBarHidden = false;
+      }
+      this.lastScrollY = yOffset;
+    })
   }
 
   @Builder
@@ -1614,11 +1688,22 @@ struct Index {
       }
       .width('100%')
       .alignItems(HorizontalAlign.Center)
+      .padding({ bottom: 80 })
     }
     .width('100%')
     .height('100%')
     .scrollBar(BarState.Off)
     .expandSafeArea([SafeAreaType.SYSTEM], [SafeAreaEdge.BOTTOM])
+    .onScroll((_: number, yOffset: number) => {
+      if (yOffset <= 0) {
+        this.tabBarHidden = false;
+      } else if (yOffset > this.lastScrollY) {
+        this.tabBarHidden = true;
+      } else if (yOffset < this.lastScrollY) {
+        this.tabBarHidden = false;
+      }
+      this.lastScrollY = yOffset;
+    })
   }
 
   @Builder
@@ -1742,11 +1827,22 @@ struct Index {
       }
       .width('100%')
       .alignItems(HorizontalAlign.Center)
+      .padding({ bottom: 80 })
     }
     .width('100%')
     .height('100%')
     .scrollBar(BarState.Off)
     .expandSafeArea([SafeAreaType.SYSTEM], [SafeAreaEdge.BOTTOM])
+    .onScroll((_: number, yOffset: number) => {
+      if (yOffset <= 0) {
+        this.tabBarHidden = false;
+      } else if (yOffset > this.lastScrollY) {
+        this.tabBarHidden = true;
+      } else if (yOffset < this.lastScrollY) {
+        this.tabBarHidden = false;
+      }
+      this.lastScrollY = yOffset;
+    })
   }
 
   private selectedSemesterName(): string {
@@ -2133,6 +2229,36 @@ struct Index {
     this.saveCoursesToPref();
   }
 
+  private async exportIcsSchedule(): Promise<void> {
+    const sem: Semester | undefined = this.selectedSemester();
+    if (sem === undefined) {
+      this.statusText = '请先导入课表';
+      return;
+    }
+    if (sem.startDate.length === 0) {
+      this.statusText = '请先设置第一周日期';
+      return;
+    }
+    const ics: string = IcsExport.generate(this.courses, sem, new Date());
+    try {
+      const docPicker = new picker.DocumentViewPicker();
+      const saveOptions: picker.DocumentSaveOptions = new picker.DocumentSaveOptions();
+      saveOptions.newFileNames = [`课表-${sem.name}.ics`];
+      saveOptions.fileSuffixChoices = ['ics'];
+      const uris: Array<string> = await docPicker.save(saveOptions);
+      if (uris.length > 0) {
+        const fileUri: string = uris[0];
+        const file = fs.openSync(fileUri, fs.OpenMode.WRITE_ONLY);
+        fs.writeSync(file.fd, ics);
+        fs.closeSync(file);
+        this.statusText = '课表已导出为日历文件';
+      }
+    } catch (e) {
+      console.error(`exportIcs failed: ${e}`);
+      this.statusText = '导出失败';
+    }
+  }
+
   @Builder
   SemesterDialogBuilder() {
     Column() {
@@ -2217,6 +2343,7 @@ struct Index {
     .height('100%')
     .justifyContent(FlexAlign.Center)
     .backgroundColor($r('app.color.overlay_dim'))
+    .zIndex(15)
   }
 
   @Builder
@@ -2333,6 +2460,7 @@ struct Index {
     .height('100%')
     .justifyContent(FlexAlign.Center)
     .backgroundColor($r('app.color.overlay_dim'))
+    .zIndex(15)
   }
 
   @Builder
@@ -2393,6 +2521,7 @@ struct Index {
     .height('100%')
     .justifyContent(FlexAlign.Center)
     .backgroundColor($r('app.color.overlay_dim'))
+    .zIndex(15)
   }
 
   @Builder
@@ -2525,6 +2654,7 @@ struct Index {
     .width('100%')
     .height('100%')
     .backgroundColor($r('app.color.page_background'))
+    .zIndex(20)
   }
 
   @Builder
@@ -2608,6 +2738,7 @@ struct Index {
     .height('100%')
     .justifyContent(FlexAlign.Center)
     .backgroundColor($r('app.color.overlay_dim'))
+    .zIndex(15)
   }
 
   @Builder
@@ -2682,5 +2813,6 @@ struct Index {
     .height('100%')
     .justifyContent(FlexAlign.Center)
     .backgroundColor($r('app.color.overlay_dim'))
+    .zIndex(15)
   }
 }


### PR DESCRIPTION
- ICS日历导出: IcsExport.ets 生成标准ICS文件, DocumentViewPicker保存
- Tab栏: 上滑translate滑出隐藏/下滑恢复, 弹窗时隐藏, WebViewOverlay zIndex(20), 对话框 zIndex(15), 各Tab底部padding避让
- 凭据持久化: 移除HUKS改用base64存储(模拟器HUKS不可用致保存挂起), 新增credentials_verified状态机, 解密失败自愈清除, 采集成功后saveCookieSync落盘会话
- 同名课合并: mergeByName空code时仅按name合并