### PR TITLE
fix: 移植安卓课表 print-data 主路径到鸿蒙 auto_collect.js

### DIFF
--- a/AoxiangAssistant/entry/src/main/ets/model/CourseModel.ets
+++ b/AoxiangAssistant/entry/src/main/ets/model/CourseModel.ets
@@ -686,6 +686,7 @@ export class Semester {
   name: string = '';
   dataSemester: string = '';
   startDate: string = '';
+  endDate: string = '';
   weekCount: number = 20;
 
   static fromJsObject(obj: Record<string, Object>): Semester {
@@ -694,13 +695,21 @@ export class Semester {
     s.dataSemester = (obj['dataSemester'] ?? '') as string;
     const sd: Object | undefined = obj['startDate'];
     s.startDate = sd !== undefined && sd !== null ? (sd as string) : '';
+    const ed: Object | undefined = obj['endDate'];
+    s.endDate = ed !== undefined && ed !== null ? (ed as string) : '';
     const wc: Object | undefined = obj['weekCount'];
     s.weekCount = wc !== undefined && wc !== null ? (wc as number) : 20;
     return s;
   }
 
   toRecord(): Record<string, Object> {
-    return { 'name': this.name, 'dataSemester': this.dataSemester, 'startDate': this.startDate, 'weekCount': this.weekCount };
+    return {
+      'name': this.name,
+      'dataSemester': this.dataSemester,
+      'startDate': this.startDate,
+      'endDate': this.endDate,
+      'weekCount': this.weekCount,
+    };
   }
 
   static computeWeekCount(courses: Course[]): number {

--- a/AoxiangAssistant/entry/src/main/ets/model/WeekUtils.ets
+++ b/AoxiangAssistant/entry/src/main/ets/model/WeekUtils.ets
@@ -150,4 +150,17 @@ export class WeekUtils {
     const day: number = d.getDate();
     return `${year}-${month < 10 ? '0' : ''}${month}-${day < 10 ? '0' : ''}${day}`;
   }
+
+  static weekCountForRange(startDate: string, endDate: string): number {
+    if (startDate.length === 0 || endDate.length === 0) {
+      return 1;
+    }
+    const start: Date = WeekUtils.mondayOnOrBefore(WeekUtils.parseStartDate(startDate));
+    const end: Date = WeekUtils.parseStartDate(endDate);
+    const diffDays: number = Math.floor((end.getTime() - start.getTime()) / WeekUtils.DAY_MS);
+    if (diffDays < 0) {
+      return 1;
+    }
+    return Math.floor(diffDays / 7) + 1;
+  }
 }

--- a/AoxiangAssistant/entry/src/main/ets/pages/Index.ets
+++ b/AoxiangAssistant/entry/src/main/ets/pages/Index.ets
@@ -968,7 +968,12 @@ struct Index {
             semCourses.push(couOut[j]);
           }
         }
-        semOut[i].weekCount = Semester.computeWeekCount(semCourses);
+        if (semOut[i].startDate.length > 0 && semOut[i].endDate.length > 0) {
+          semOut[i].weekCount = WeekUtils.weekCountForRange(semOut[i].startDate, semOut[i].endDate);
+          console.info(`weekCount from range: sem='${semOut[i].name}' start=${semOut[i].startDate} end=${semOut[i].endDate} weeks=${semOut[i].weekCount}`);
+        } else {
+          semOut[i].weekCount = Semester.computeWeekCount(semCourses);
+        }
       }
     }
     const defaultSemester: string = semOut.length > 0 ? semOut[0].dataSemester : 'current';

--- a/AoxiangAssistant/entry/src/main/resources/rawfile/auto_collect.js
+++ b/AoxiangAssistant/entry/src/main/resources/rawfile/auto_collect.js
@@ -9,7 +9,7 @@
   const headless = __HEADLESS__;
   const collectionMode = mode === "grades" || mode === "schedule" || mode === "electricity";
 
-  const text = (value) => (value || "").replace(/\s+/g, " ").trim();
+  const text = (value) => String(value == null ? "" : value).replace(/\s+/g, " ").trim();
   const visible = (element) => {
     try {
       if (headless) {
@@ -499,9 +499,225 @@
     return records;
   };
 
+  const scheduleDateFromPage = () => {
+    for (const doc of documents) {
+      const pageText = text(doc.body ? doc.body.innerText : "");
+      const match = pageText.match(/学期起始日期\s*[：:]?\s*(\d{4}-\d{2}-\d{2})/);
+      if (match) return match[1];
+    }
+    return "";
+  };
+
+  const compactWeeks = (values) => {
+    const weeks = [...new Set((Array.isArray(values) ? values : [])
+      .map((value) => Number.parseInt(value, 10))
+      .filter((value) => Number.isFinite(value) && value > 0))].sort((left, right) => left - right);
+    const ranges = [];
+    for (let index = 0; index < weeks.length;) {
+      const start = weeks[index];
+      let end = start;
+      while (index + 1 < weeks.length && weeks[index + 1] === end + 1) {
+        index++;
+        end = weeks[index];
+      }
+      ranges.push(start === end ? String(start) : `${start}~${end}`);
+      index++;
+    }
+    return ranges.length ? `${ranges.join(",")}周` : "1~17周";
+  };
+
+  const scheduleLastCourseDate = (activities, startDate) => {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(startDate) || !Array.isArray(activities)) return "";
+    const parts = startDate.split("-").map((value) => Number.parseInt(value, 10));
+    const start = new Date(Date.UTC(parts[0], parts[1] - 1, parts[2]));
+    // An empty or very short timetable still represents a two-week semester window.
+    let lastOffset = 13;
+    activities.forEach((activity) => {
+      const day = Number.parseInt(activity && activity.weekday, 10);
+      if (day < 1 || day > 7) return;
+      (Array.isArray(activity.weekIndexes) ? activity.weekIndexes : []).forEach((value) => {
+        const week = Number.parseInt(value, 10);
+        if (Number.isFinite(week) && week > 0) {
+          lastOffset = Math.max(lastOffset, (week - 1) * 7 + day - 1);
+        }
+      });
+    });
+    start.setUTCDate(start.getUTCDate() + lastOffset);
+    return start.toISOString().slice(0, 10);
+  };
+
+  const schedulePayloadFromPrintData = (data) => {
+    const table = data && data.studentTableVm;
+    const activities = table && Array.isArray(table.activities) ? table.activities : [];
+    const arranged = table && Array.isArray(table.arrangedLessonSearchVms)
+      ? table.arrangedLessonSearchVms : [];
+    const lessonWithSemester = arranged.find((lesson) => lesson && lesson.semester);
+    const semester = lessonWithSemester ? lessonWithSemester.semester : null;
+    const semesterControl = scheduleSemesterControl();
+    const selectedOption = semesterControl && semesterControl.options.find(
+      (option) => option.value === semesterControl.currentValue);
+    const dataSemester = text(semester && (semester.id || semester.code)) ||
+      text(semesterControl && semesterControl.currentValue) || "current";
+    const semesterName = text(semester && (semester.nameZh || semester.name || semester.code)) ||
+      text(selectedOption && selectedOption.name) || "当前学期";
+    const startDate = text(semester && semester.startDate) || scheduleDateFromPage();
+    const endDate = scheduleLastCourseDate(activities, startDate) || text(semester && semester.endDate);
+    const semesters = [{
+      name: semesterName,
+      dataSemester,
+      startDate: startDate || undefined,
+      endDate: endDate || undefined
+    }];
+    const courses = [];
+    const seenCourses = new Set();
+
+    activities.forEach((activity) => {
+      if (!activity || !activity.courseName) return;
+      const day = Number.parseInt(activity.weekday, 10);
+      const startUnit = Number.parseInt(activity.startUnit, 10);
+      const endUnit = Number.parseInt(activity.endUnit, 10);
+      if (!dayLabels[day] || !Number.isFinite(startUnit) || !Number.isFinite(endUnit)) return;
+      const teachers = (Array.isArray(activity.teachers) ? activity.teachers : [])
+        .map((teacher) => text(typeof teacher === "string" ? teacher
+          : teacher && (teacher.nameZh || teacher.name || teacher.teacherName)))
+        .filter(Boolean);
+      const locationParts = [activity.campus, activity.building, activity.room]
+        .map(text).filter((value, index, values) => value && values.indexOf(value) === index);
+      const course = {
+        name: text(activity.courseName),
+        code: text(activity.courseCode) || undefined,
+        credits: toMaybeNumber(activity.credits),
+        teacher: teachers.length ? [...new Set(teachers)].join("、") : undefined,
+        scheduleText: `${compactWeeks(activity.weekIndexes)} ${dayLabels[day]} ${startUnit}-${endUnit}节`,
+        location: locationParts.length ? locationParts.join(" ") : undefined,
+        dataSemester
+      };
+      if (onlinePattern.test([course.name, course.location || ""].join(" "))) return;
+      uniquePush(courses, seenCourses, course);
+    });
+    return { semesters, courses };
+  };
+
+  const schedulePrintDataUrls = () => {
+    try {
+      return performance.getEntriesByType("resource")
+        .map((entry) => entry.name || "")
+        .filter((url) => /\/for-std\/course-table\/semester\/[^/]+\/print-data\/[^/?#]+/.test(url));
+    } catch (ignored) {
+      return [];
+    }
+  };
+
+  const schedulePrintDataUrl = (dataSemester) => {
+    const encodedSemester = encodeURIComponent(String(dataSemester || ""));
+    return [...schedulePrintDataUrls()].reverse().find((url) =>
+      !encodedSemester || new RegExp("/semester/" + encodedSemester + "/print-data/").test(url)) || "";
+  };
+
+  const schedulePrintDataKey = (url) => {
+    try {
+      return new URL(url, location.origin).pathname;
+    } catch (ignored) {
+      return url || "";
+    }
+  };
+
+  const scheduleSemesterSortKey = (name) => {
+    const match = text(name).match(/(\d{4})\s*[-—]\s*\d{4}.*?(秋|冬|春|夏)/);
+    if (!match) return Number.NaN;
+    const seasonOrder = { "秋": 0, "冬": 1, "春": 2, "夏": 3 };
+    return Number.parseInt(match[1], 10) * 10 + seasonOrder[match[2]];
+  };
+
+  const scheduleSemesterControl = () => {
+    const element = document.querySelector("#allSemesters");
+    const selectize = element && element.selectize;
+    if (!selectize) return null;
+    const options = Object.values(selectize.options || {})
+      .map((option) => ({
+        name: text(option && (option.text || option.name || option.label)),
+        value: text(option && (option.value || option.id || option.code))
+      }))
+      .filter((option) => option.name && option.value && Number.isFinite(scheduleSemesterSortKey(option.name)))
+      .sort((left, right) => scheduleSemesterSortKey(left.name) - scheduleSemesterSortKey(right.name));
+    const currentValue = text((selectize.items || [])[0] || element.value);
+    return { selectize, options, currentValue };
+  };
+
+  const todayString = () => {
+    const now = new Date();
+    const pad = (value) => String(value).padStart(2, "0");
+    return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+  };
+
+  const scheduleSemesterStateKey = "__aoxiangAssistantScheduleSemester";
+
+  const prepareCurrentScheduleSemester = () => {
+    const control = scheduleSemesterControl();
+    if (!control || !control.options.length) {
+      return { ready: true, printDataUrl: schedulePrintDataUrl("") };
+    }
+
+    const state = window[scheduleSemesterStateKey] || { dates: {} };
+    window[scheduleSemesterStateKey] = state;
+    const printDataUrls = schedulePrintDataUrls();
+
+    if (state.pendingValue) {
+      if (control.currentValue !== state.pendingValue ||
+          printDataUrls.length <= state.pendingResourceCount) {
+        return { ready: false };
+      }
+      state.pendingValue = "";
+    }
+
+    const currentIndex = control.options.findIndex((option) => option.value === control.currentValue);
+    if (currentIndex < 0) return { ready: true, printDataUrl: schedulePrintDataUrl("") };
+    const currentStartDate = scheduleDateFromPage();
+    const currentPrintDataUrl = schedulePrintDataUrl(control.currentValue);
+    if (!currentStartDate || !currentPrintDataUrl) return { ready: false };
+    state.dates[control.currentValue] = currentStartDate;
+
+    if (state.forcedTargetValue === control.currentValue) {
+      state.targetValue = control.currentValue;
+      return { ready: true, printDataUrl: currentPrintDataUrl };
+    }
+
+    const switchTo = (option) => {
+      if (!option || option.value === control.currentValue) return { ready: false };
+      state.pendingValue = option.value;
+      state.pendingResourceCount = printDataUrls.length;
+      control.selectize.setValue(option.value);
+      return { ready: false };
+    };
+
+    const today = todayString();
+    if (today < currentStartDate && currentIndex > 0) {
+      return switchTo(control.options[currentIndex - 1]);
+    }
+
+    state.targetValue = control.currentValue;
+    return { ready: true, printDataUrl: currentPrintDataUrl };
+  };
+
+  const selectNextScheduleSemester = () => {
+    const control = scheduleSemesterControl();
+    if (!control) return false;
+    const currentIndex = control.options.findIndex((option) => option.value === control.currentValue);
+    const nextOption = control.options[currentIndex + 1];
+    if (currentIndex < 0 || !nextOption) return false;
+    const state = window[scheduleSemesterStateKey] || { dates: {} };
+    state.forcedTargetValue = nextOption.value;
+    state.pendingValue = nextOption.value;
+    state.pendingResourceCount = schedulePrintDataUrls().length;
+    window[scheduleSemesterStateKey] = state;
+    control.selectize.setValue(nextOption.value);
+    return true;
+  };
+
   const extractSchedulePayload = () => {
     const semesters = [];
     const seenSemesters = new Set();
+    const pageStartDate = scheduleDateFromPage();
 
     documents.forEach((doc) => {
       [...doc.querySelectorAll("select option")].forEach((option) => {
@@ -513,7 +729,11 @@
         const key = dataSemester + "|" + name;
         if (seenSemesters.has(key)) return;
         seenSemesters.add(key);
-        semesters.push({ name, dataSemester });
+        semesters.push({
+          name,
+          dataSemester,
+          startDate: option.selected && pageStartDate ? pageStartDate : undefined
+        });
       });
     });
 
@@ -632,7 +852,7 @@
           const key = dataSemester + "|" + name;
           if (seenSemesters.has(key)) return;
           seenSemesters.add(key);
-          semesters.push({ name, dataSemester });
+          semesters.push({ name, dataSemester, startDate: pageStartDate || undefined });
         });
 
         const rowMatches = [...html.matchAll(/<tr[^>]*>([\s\S]*?)<\/tr>/g)];
@@ -672,18 +892,57 @@
       const firstCourseSemester = courses.find((course) => course.dataSemester && semesterValuePattern.test(course.dataSemester));
       semesters.push({
         name: firstCourseSemester ? firstCourseSemester.dataSemester : "当前学期",
-        dataSemester: firstCourseSemester ? firstCourseSemester.dataSemester : "current"
+        dataSemester: firstCourseSemester ? firstCourseSemester.dataSemester : "current",
+        startDate: pageStartDate || undefined
       });
     }
 
     return { semesters, courses };
   };
 
-  const schedulePayload = extractSchedulePayload();
   if (mode === "schedule") {
-    if (schedulePayload.courses.length) {
-      return JSON.stringify({ phase: "schedule_data", payload: schedulePayload });
+    const semesterSelection = prepareCurrentScheduleSemester();
+    if (!semesterSelection.ready) return JSON.stringify({ phase: "page", rows: [] });
+    const printDataUrl = semesterSelection.printDataUrl;
+    const printDataKey = schedulePrintDataKey(printDataUrl);
+    const stateKey = "__aoxiangAssistantSchedulePrintData";
+    let state = window[stateKey];
+    if (printDataUrl && (!state || state.key !== printDataKey)) {
+      state = { key: printDataKey, loading: true };
+      window[stateKey] = state;
+      fetch(printDataUrl, { credentials: "same-origin" })
+        .then((response) => {
+          if (!response.ok) throw new Error(`HTTP ${response.status}`);
+          return response.json();
+        })
+        .then((data) => {
+          state.data = data;
+          state.loading = false;
+        })
+        .catch(() => {
+          state.failed = true;
+          state.loading = false;
+        });
+      return JSON.stringify({ phase: "page", rows: [] });
     }
+    if (state && state.loading) return JSON.stringify({ phase: "page", rows: [] });
+    if (state && state.data) {
+      const table = state.data.studentTableVm;
+      if (table && Array.isArray(table.activities)) {
+        const structuredPayload = schedulePayloadFromPrintData(state.data);
+        const semester = structuredPayload.semesters[0];
+        if (semester && semester.endDate && todayString() > semester.endDate &&
+            selectNextScheduleSemester()) {
+          return JSON.stringify({ phase: "page", rows: [] });
+        }
+        return JSON.stringify({ phase: "schedule_data", payload: structuredPayload });
+      }
+    }
+  }
+
+  const schedulePayload = extractSchedulePayload();
+  if (mode === "schedule" && schedulePayload.courses.length) {
+    return JSON.stringify({ phase: "schedule_data", payload: schedulePayload });
   }
 
   return JSON.stringify({


### PR DESCRIPTION
- 新增 12 个学期/print-data 函数（scheduleSemesterControl/prepareCurrentScheduleSemester/ schedulePayloadFromPrintData/compactWeeks/scheduleLastCourseDate 等）
- schedule 出口改为两级：print-data 结构化解析优先，HTML 表格抓取兜底
- 学期选择走页面 #allSemesters selectize，print-data URL 取自 performance resource
- 修 text() 对非字符串入参崩溃（(value || '') -> String(value == null ? '' : value)）
- semesters.push 回填 startDate（3 处）
- Semester 新增 endDate 字段，fromJsObject/toRecord 同步
- WeekUtils 新增 weekCountForRange（对齐 ScheduleUtils.weekCountForRange）
- handleCollectedSchedule 有 startDate+endDate 时按日期跨度算 weekCount