### PR TITLE
feat: 桌面服务卡片 - 每日课表/今明课表/每周课表/电费卡片

### DIFF
--- a/AoxiangAssistant/entry/src/main/ets/entryformability/EntryFormAbility.ets
+++ b/AoxiangAssistant/entry/src/main/ets/entryformability/EntryFormAbility.ets
@@ -1,0 +1,60 @@
+import { FormExtensionAbility, formBindingData, formInfo, formProvider } from '@kit.FormKit';
+import { Want } from '@kit.AbilityKit';
+import { BusinessError } from '@kit.BasicServicesKit';
+import { WidgetDataBuilder } from '../model/WidgetDataBuilder';
+import { WidgetSnapshotStore } from '../model/WidgetSnapshotStore';
+
+export default class EntryFormAbility extends FormExtensionAbility {
+  onAddForm(want: Want): formBindingData.FormBindingData {
+    const parameters: Record<string, Object> = want.parameters as Record<string, Object>;
+    if (parameters === undefined || parameters === null) {
+      return formBindingData.createFormBindingData({});
+    }
+    const formName: string = (parameters[formInfo.FormParam.NAME_KEY] as string) ?? 'daily_card';
+    const formId: string = (parameters[formInfo.FormParam.IDENTITY_KEY] as string) ?? '';
+    console.info(`EntryFormAbility.onAddForm formId=${formId} name=${formName}`);
+    const data: formBindingData.FormBindingData =
+      this.initialBindingData(formName);
+    if (formId.length > 0) {
+      WidgetSnapshotStore.registerForm(this.context, formId, formName)
+        .catch((e: BusinessError) => {
+          console.error(`registerForm error: ${e.code} ${e.message}`);
+        });
+    }
+    return data;
+  }
+
+  onUpdateForm(formId: string): void {
+    console.info(`EntryFormAbility.onUpdateForm formId=${formId}`);
+    WidgetSnapshotStore.findFormName(this.context, formId).then((formName: string) => {
+      const name: string = formName.length > 0 ? formName : 'daily_card';
+      WidgetSnapshotStore.loadSnapshot(this.context, name).then((json: string) => {
+        const data: string = json.length > 0 ? json : WidgetDataBuilder.defaultJson(name);
+        formProvider.updateForm(formId, formBindingData.createFormBindingData({ cardData: data }))
+          .then(() => {
+            console.info(`updateForm ok formId=${formId} name=${name}`);
+          })
+          .catch((e: BusinessError) => {
+            console.error(`updateForm error: ${e.code} ${e.message}`);
+          });
+      });
+    });
+  }
+
+  onRemoveForm(formId: string): void {
+    console.info(`EntryFormAbility.onRemoveForm formId=${formId}`);
+    WidgetSnapshotStore.unregisterForm(this.context, formId)
+      .catch((e: BusinessError) => {
+        console.error(`unregisterForm error: ${e.code} ${e.message}`);
+      });
+  }
+
+  onFormEvent(formId: string, message: string): void {
+    console.info(`EntryFormAbility.onFormEvent formId=${formId} message=${message}`);
+  }
+
+  private initialBindingData(formName: string): formBindingData.FormBindingData {
+    const data: string = WidgetDataBuilder.defaultJson(formName);
+    return formBindingData.createFormBindingData({ cardData: data });
+  }
+}

--- a/AoxiangAssistant/entry/src/main/ets/model/WidgetDataBuilder.ets
+++ b/AoxiangAssistant/entry/src/main/ets/model/WidgetDataBuilder.ets
@@ -1,0 +1,293 @@
+import { Course, Semester, TimeSlot } from './CourseModel';
+import { WeekUtils } from './WeekUtils';
+import { ScheduleTimes } from './ScheduleTimes';
+
+export class WidgetFormNames {
+  static readonly DAILY: string = 'daily_card';
+  static readonly TODAY_TOMORROW: string = 'today_tomorrow_card';
+  static readonly WEEKLY: string = 'weekly_card';
+  static readonly ELECTRICITY: string = 'electricity_card';
+}
+
+class WidgetCourseItem {
+  time: string = '';
+  name: string = '';
+  loc: string = '';
+  teacher: string = '';
+  color: string = '';
+  section: string = '';
+}
+
+class WidgetDayGroup {
+  label: string = '';
+  date: string = '';
+  courses: WidgetCourseItem[] = [];
+}
+
+class SlotRef {
+  course: Course | undefined = undefined;
+  slot: TimeSlot | undefined = undefined;
+}
+
+export class WidgetSnapshot {
+  formName: string = '';
+  json: string = '';
+}
+
+export class WidgetDataBuilder {
+  private static readonly DAY_LABELS: string[] = ['', '周一', '周二', '周三', '周四', '周五', '周六', '周日'];
+
+  static buildAll(courses: Course[], semesters: Semester[], semesterIndex: number,
+                  balance: number, now: Date): WidgetSnapshot[] {
+    const out: WidgetSnapshot[] = [];
+    out.push(WidgetDataBuilder.snapshot(WidgetFormNames.DAILY,
+      WidgetDataBuilder.buildDaily(courses, semesters, semesterIndex, now)));
+    out.push(WidgetDataBuilder.snapshot(WidgetFormNames.TODAY_TOMORROW,
+      WidgetDataBuilder.buildTodayTomorrow(courses, semesters, semesterIndex, now)));
+    out.push(WidgetDataBuilder.snapshot(WidgetFormNames.WEEKLY,
+      WidgetDataBuilder.buildWeekly(courses, semesters, semesterIndex, now)));
+    out.push(WidgetDataBuilder.snapshot(WidgetFormNames.ELECTRICITY,
+      WidgetDataBuilder.buildElectricity(balance, now)));
+    return out;
+  }
+
+  static emptyAll(now: Date): WidgetSnapshot[] {
+    return WidgetDataBuilder.buildAll([], [], 0, -1, now);
+  }
+
+  private static snapshot(formName: string, json: string): WidgetSnapshot {
+    const snap: WidgetSnapshot = new WidgetSnapshot();
+    snap.formName = formName;
+    snap.json = json;
+    return snap;
+  }
+
+  static defaultJson(formName: string): string {
+    if (formName === WidgetFormNames.ELECTRICITY) {
+      return WidgetDataBuilder.buildElectricity(-1, new Date());
+    }
+    if (formName === WidgetFormNames.TODAY_TOMORROW) {
+      return WidgetDataBuilder.buildTodayTomorrow([], [], 0, new Date());
+    }
+    if (formName === WidgetFormNames.WEEKLY) {
+      return WidgetDataBuilder.buildWeekly([], [], 0, new Date());
+    }
+    return WidgetDataBuilder.buildDaily([], [], 0, new Date());
+  }
+
+  private static activeSemester(semesters: Semester[], semesterIndex: number): Semester | undefined {
+    if (semesters.length === 0) {
+      return undefined;
+    }
+    const idx: number = semesterIndex >= 0 && semesterIndex < semesters.length ? semesterIndex : 0;
+    return semesters[idx];
+  }
+
+  private static currentWeek(sem: Semester | undefined): number {
+    if (sem === undefined || sem.startDate.length === 0) {
+      return 0;
+    }
+    return WeekUtils.currentWeek(sem.startDate, sem.weekCount, 0);
+  }
+
+  private static hintFor(sem: Semester | undefined, week: number): string {
+    if (sem === undefined) {
+      return '请先导入课表';
+    }
+    if (week <= 0) {
+      return '请先设置第一周';
+    }
+    return '';
+  }
+
+  private static dayOfWeekFor(date: Date): number {
+    const day: number = date.getDay();
+    return day === 0 ? 7 : day;
+  }
+
+  private static slotCampus(slot: TimeSlot): string {
+    return slot.campus.length > 0 ? slot.campus : '长安校区';
+  }
+
+  private static coursesForDay(courses: Course[], week: number, day: number, date: Date): WidgetCourseItem[] {
+    const items: WidgetCourseItem[] = [];
+    if (week <= 0 || day < 1 || day > 7) {
+      return items;
+    }
+    const matched: SlotRef[] = [];
+    for (let i = 0; i < courses.length; i++) {
+      const course: Course = courses[i];
+      for (let j = 0; j < course.timeSlots.length; j++) {
+        const slot: TimeSlot = course.timeSlots[j];
+        if (slot.dayOfWeek !== day || slot.sectionStart < 1 || slot.sectionEnd < slot.sectionStart) {
+          continue;
+        }
+        if (!WeekUtils.isWeekInRange(week, slot.weekRange)) {
+          continue;
+        }
+        if (!WeekUtils.matchesRepeatRule(week, slot.repeatRule)) {
+          continue;
+        }
+        const ref: SlotRef = new SlotRef();
+        ref.course = course;
+        ref.slot = slot;
+        matched.push(ref);
+      }
+    }
+    matched.sort((a: SlotRef, b: SlotRef) => {
+      const sa: number = a.slot !== undefined ? a.slot.sectionStart : 99;
+      const sb: number = b.slot !== undefined ? b.slot.sectionStart : 99;
+      return sa - sb;
+    });
+    for (let i = 0; i < matched.length; i++) {
+      const ref: SlotRef = matched[i];
+      if (ref.course === undefined || ref.slot === undefined) {
+        continue;
+      }
+      const course: Course = ref.course;
+      const slot: TimeSlot = ref.slot;
+      const item: WidgetCourseItem = new WidgetCourseItem();
+      item.name = course.name;
+      item.time = ScheduleTimes.timeSpanFor(WidgetDataBuilder.slotCampus(slot), date,
+        slot.sectionStart, slot.sectionEnd);
+      item.section = slot.sectionEnd > slot.sectionStart
+        ? `${slot.sectionStart}-${slot.sectionEnd}节`
+        : `${slot.sectionStart}节`;
+      item.loc = slot.location.length > 0 ? slot.location : course.location;
+      item.teacher = course.teacher;
+      item.color = course.getColor();
+      items.push(item);
+    }
+    return items;
+  }
+
+  private static dayGroup(courses: Course[], week: number, date: Date, label: string): WidgetDayGroup {
+    const group: WidgetDayGroup = new WidgetDayGroup();
+    const day: number = WidgetDataBuilder.dayOfWeekFor(date);
+    group.label = label.length > 0 ? label : WidgetDataBuilder.DAY_LABELS[day];
+    group.date = WeekUtils.formatMD(date);
+    group.courses = WidgetDataBuilder.coursesForDay(courses, week, day, date);
+    return group;
+  }
+
+  private static courseItemRecord(item: WidgetCourseItem): Record<string, Object> {
+    return {
+      'time': item.time,
+      'section': item.section,
+      'name': item.name,
+      'loc': item.loc,
+      'teacher': item.teacher,
+      'color': item.color,
+    };
+  }
+
+  private static courseItemArray(items: WidgetCourseItem[]): Object[] {
+    const arr: Object[] = [];
+    for (let i = 0; i < items.length; i++) {
+      arr.push(WidgetDataBuilder.courseItemRecord(items[i]));
+    }
+    return arr;
+  }
+
+  private static dayGroupRecord(group: WidgetDayGroup): Record<string, Object> {
+    return {
+      'label': group.label,
+      'date': group.date,
+      'empty': group.courses.length === 0,
+      'courses': WidgetDataBuilder.courseItemArray(group.courses),
+    };
+  }
+
+  private static buildDaily(courses: Course[], semesters: Semester[], semesterIndex: number,
+                            now: Date): string {
+    const sem: Semester | undefined = WidgetDataBuilder.activeSemester(semesters, semesterIndex);
+    const week: number = WidgetDataBuilder.currentWeek(sem);
+    const group: WidgetDayGroup = WidgetDataBuilder.dayGroup(courses, week, now, '今天');
+    const payload: Record<string, Object> = {
+      'title': week > 0 ? `第${week}周 ${group.label}` : '今日课表',
+      'date': group.date,
+      'hint': WidgetDataBuilder.hintFor(sem, week),
+      'empty': group.courses.length === 0,
+      'courses': WidgetDataBuilder.courseItemArray(group.courses),
+    };
+    return JSON.stringify(payload);
+  }
+
+  private static buildTodayTomorrow(courses: Course[], semesters: Semester[], semesterIndex: number,
+                                    now: Date): string {
+    const sem: Semester | undefined = WidgetDataBuilder.activeSemester(semesters, semesterIndex);
+    const tomorrow: Date = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+    const weekToday: number = WidgetDataBuilder.currentWeek(sem);
+    let weekTomorrow: number = weekToday;
+    if (sem !== undefined && sem.startDate.length > 0) {
+      weekTomorrow = WeekUtils.weekNumberForDate(tomorrow, sem.startDate);
+      if (weekTomorrow < 1) {
+        weekTomorrow = weekToday;
+      }
+    }
+    const groups: Object[] = [];
+    groups.push(WidgetDataBuilder.dayGroupRecord(
+      WidgetDataBuilder.dayGroup(courses, weekToday, now, '今天')));
+    groups.push(WidgetDataBuilder.dayGroupRecord(
+      WidgetDataBuilder.dayGroup(courses, weekTomorrow, tomorrow, '明天')));
+    const payload: Record<string, Object> = {
+      'title': weekToday > 0 ? `第${weekToday}周` : '今明课表',
+      'hint': WidgetDataBuilder.hintFor(sem, weekToday),
+      'days': groups,
+    };
+    return JSON.stringify(payload);
+  }
+
+  private static buildWeekly(courses: Course[], semesters: Semester[], semesterIndex: number,
+                             now: Date): string {
+    const sem: Semester | undefined = WidgetDataBuilder.activeSemester(semesters, semesterIndex);
+    const week: number = WidgetDataBuilder.currentWeek(sem);
+    const groups: Object[] = [];
+    let total: number = 0;
+    const todayDay: number = WidgetDataBuilder.dayOfWeekFor(now);
+    let weekStart: Date = now;
+    if (sem !== undefined && sem.startDate.length > 0 && week > 0) {
+      weekStart = WeekUtils.weekStart(sem.startDate, week);
+    } else {
+      weekStart = new Date(now.getTime() - (todayDay - 1) * 24 * 60 * 60 * 1000);
+    }
+    for (let i = 0; i < 7; i++) {
+      const date: Date = new Date(weekStart.getTime() + i * 24 * 60 * 60 * 1000);
+      const group: WidgetDayGroup = WidgetDataBuilder.dayGroup(courses, week, date,
+        WidgetDataBuilder.DAY_LABELS[i + 1]);
+      total += group.courses.length;
+      const record: Record<string, Object> = WidgetDataBuilder.dayGroupRecord(group);
+      record['today'] = (i + 1) === todayDay;
+      groups.push(record);
+    }
+    const payload: Record<string, Object> = {
+      'title': week > 0 ? `第${week}周课表` : '每周课表',
+      'hint': WidgetDataBuilder.hintFor(sem, week),
+      'empty': total === 0,
+      'days': groups,
+    };
+    return JSON.stringify(payload);
+  }
+
+  private static buildElectricity(balance: number, now: Date): string {
+    const ok: boolean = balance >= 0;
+    const payload: Record<string, Object> = {
+      'value': ok ? balance.toFixed(2) : '--',
+      'unit': '元',
+      'empty': !ok,
+      'hint': ok ? '' : '打开应用查询电费',
+      'updated': ok ? WidgetDataBuilder.timeLabel(now) : '',
+    };
+    return JSON.stringify(payload);
+  }
+
+  private static timeLabel(date: Date): string {
+    const month: number = date.getMonth() + 1;
+    const day: number = date.getDate();
+    const hour: number = date.getHours();
+    const minute: number = date.getMinutes();
+    const hh: string = hour < 10 ? `0${hour}` : `${hour}`;
+    const mm: string = minute < 10 ? `0${minute}` : `${minute}`;
+    return `${month}/${day} ${hh}:${mm}`;
+  }
+}

--- a/AoxiangAssistant/entry/src/main/ets/model/WidgetPusher.ets
+++ b/AoxiangAssistant/entry/src/main/ets/model/WidgetPusher.ets
@@ -1,0 +1,24 @@
+import { common } from '@kit.AbilityKit';
+import { formProvider } from '@kit.FormKit';
+import { Course, Semester } from './CourseModel';
+import { WidgetDataBuilder, WidgetSnapshot } from './WidgetDataBuilder';
+import { WidgetSnapshotStore } from './WidgetSnapshotStore';
+
+export class WidgetPusher {
+  static async refresh(context: common.UIAbilityContext, courses: Course[], semesters: Semester[],
+                       semesterIndex: number, balance: number): Promise<void> {
+    try {
+      const snaps: WidgetSnapshot[] = WidgetDataBuilder.buildAll(courses, semesters, semesterIndex,
+        balance, new Date());
+      const pairs: Array<[string, string]> = [];
+      for (let i = 0; i < snaps.length; i++) {
+        pairs.push([snaps[i].formName, snaps[i].json]);
+      }
+      await WidgetSnapshotStore.saveSnapshots(context, pairs);
+      const notified: number = await formProvider.reloadAllForms(context);
+      console.info(`WidgetPusher.refresh: snapshots=${pairs.length} forms=${notified}`);
+    } catch (e) {
+      console.error(`WidgetPusher.refresh error: ${e}`);
+    }
+  }
+}

--- a/AoxiangAssistant/entry/src/main/ets/model/WidgetSnapshotStore.ets
+++ b/AoxiangAssistant/entry/src/main/ets/model/WidgetSnapshotStore.ets
@@ -1,0 +1,149 @@
+import { common } from '@kit.AbilityKit';
+import { preferences } from '@kit.ArkData';
+
+class WidgetFormReg {
+  formId: string = '';
+  formName: string = '';
+}
+
+export class WidgetSnapshotStore {
+  private static readonly STORE_NAME: string = 'widget_store';
+  private static readonly REGISTRY_KEY: string = 'form_registry';
+  private static readonly PREFIX: string = 'snap_';
+
+  private static async open(context: common.Context): Promise<preferences.Preferences | undefined> {
+    try {
+      const options: preferences.Options = {
+        name: WidgetSnapshotStore.STORE_NAME,
+        storageType: preferences.StorageType.GSKV,
+      };
+      return await preferences.getPreferences(context, options);
+    } catch (e) {
+      console.error(`WidgetSnapshotStore.open error: ${e}`);
+      return undefined;
+    }
+  }
+
+  static async saveSnapshots(context: common.Context, snaps: Array<[string, string]>): Promise<void> {
+    const pref: preferences.Preferences | undefined = await WidgetSnapshotStore.open(context);
+    if (pref === undefined) {
+      return;
+    }
+    try {
+      for (let i = 0; i < snaps.length; i++) {
+        pref.putSync(WidgetSnapshotStore.PREFIX + snaps[i][0], snaps[i][1]);
+      }
+      await pref.flush();
+    } catch (e) {
+      console.error(`WidgetSnapshotStore.saveSnapshots error: ${e}`);
+    }
+  }
+
+  static async loadSnapshot(context: common.Context, formName: string): Promise<string> {
+    const pref: preferences.Preferences | undefined = await WidgetSnapshotStore.open(context);
+    if (pref === undefined) {
+      return '';
+    }
+    try {
+      return pref.getSync(WidgetSnapshotStore.PREFIX + formName, '') as string;
+    } catch (e) {
+      console.error(`WidgetSnapshotStore.loadSnapshot error: ${e}`);
+      return '';
+    }
+  }
+
+  static async registerForm(context: common.Context, formId: string, formName: string): Promise<void> {
+    const pref: preferences.Preferences | undefined = await WidgetSnapshotStore.open(context);
+    if (pref === undefined) {
+      return;
+    }
+    try {
+      const raw: string = pref.getSync(WidgetSnapshotStore.REGISTRY_KEY, '') as string;
+      let regs: WidgetFormReg[] = [];
+      if (raw.length > 0) {
+        const arr: Object[] = JSON.parse(raw) as Object[];
+        for (let i = 0; i < arr.length; i++) {
+          const obj: Record<string, Object> = arr[i] as Record<string, Object>;
+          const reg: WidgetFormReg = new WidgetFormReg();
+          reg.formId = (obj['formId'] ?? '') as string;
+          reg.formName = (obj['formName'] ?? '') as string;
+          if (reg.formId.length > 0) {
+            regs.push(reg);
+          }
+        }
+      }
+      regs = regs.filter((reg: WidgetFormReg) => reg.formId !== formId);
+      const reg: WidgetFormReg = new WidgetFormReg();
+      reg.formId = formId;
+      reg.formName = formName;
+      regs.push(reg);
+      pref.putSync(WidgetSnapshotStore.REGISTRY_KEY, JSON.stringify(WidgetSnapshotStore.registryJson(regs)));
+      await pref.flush();
+    } catch (e) {
+      console.error(`WidgetSnapshotStore.registerForm error: ${e}`);
+    }
+  }
+
+  static async unregisterForm(context: common.Context, formId: string): Promise<void> {
+    const pref: preferences.Preferences | undefined = await WidgetSnapshotStore.open(context);
+    if (pref === undefined) {
+      return;
+    }
+    try {
+      const raw: string = pref.getSync(WidgetSnapshotStore.REGISTRY_KEY, '') as string;
+      let regs: WidgetFormReg[] = [];
+      if (raw.length > 0) {
+        const arr: Object[] = JSON.parse(raw) as Object[];
+        for (let i = 0; i < arr.length; i++) {
+          const obj: Record<string, Object> = arr[i] as Record<string, Object>;
+          const reg: WidgetFormReg = new WidgetFormReg();
+          reg.formId = (obj['formId'] ?? '') as string;
+          reg.formName = (obj['formName'] ?? '') as string;
+          if (reg.formId.length > 0) {
+            regs.push(reg);
+          }
+        }
+      }
+      regs = regs.filter((reg: WidgetFormReg) => reg.formId !== formId);
+      pref.putSync(WidgetSnapshotStore.REGISTRY_KEY, JSON.stringify(WidgetSnapshotStore.registryJson(regs)));
+      await pref.flush();
+    } catch (e) {
+      console.error(`WidgetSnapshotStore.unregisterForm error: ${e}`);
+    }
+  }
+
+  static async findFormName(context: common.Context, formId: string): Promise<string> {
+    const pref: preferences.Preferences | undefined = await WidgetSnapshotStore.open(context);
+    if (pref === undefined) {
+      return '';
+    }
+    try {
+      const raw: string = pref.getSync(WidgetSnapshotStore.REGISTRY_KEY, '') as string;
+      if (raw.length === 0) {
+        return '';
+      }
+      const arr: Object[] = JSON.parse(raw) as Object[];
+      for (let i = 0; i < arr.length; i++) {
+        const obj: Record<string, Object> = arr[i] as Record<string, Object>;
+        if ((obj['formId'] ?? '') === formId) {
+          return (obj['formName'] ?? '') as string;
+        }
+      }
+    } catch (e) {
+      console.error(`WidgetSnapshotStore.findFormName error: ${e}`);
+    }
+    return '';
+  }
+
+  private static registryJson(regs: WidgetFormReg[]): Object[] {
+    const arr: Object[] = [];
+    for (let i = 0; i < regs.length; i++) {
+      const obj: Record<string, Object> = {
+        'formId': regs[i].formId,
+        'formName': regs[i].formName,
+      };
+      arr.push(obj);
+    }
+    return arr;
+  }
+}

--- a/AoxiangAssistant/entry/src/main/ets/pages/Index.ets
+++ b/AoxiangAssistant/entry/src/main/ets/pages/Index.ets
@@ -13,6 +13,7 @@ import { AppLogger } from '../model/AppLogger';
 import { ScheduleGrid } from '../components/ScheduleGrid';
 import { Constants, LoginPhase, LoginTarget } from '../common/Constants';
 import { BusinessError } from '@kit.BasicServicesKit';
+import { WidgetPusher } from '../model/WidgetPusher';
 
 @Entry
 @Component
@@ -89,6 +90,17 @@ struct Index {
     this.loadElectricityFromPref();
     this.loadCoursesFromPref();
     console.info(`aboutToAppear done: grades=${this.grades.length} electricity=${this.electricityBalance} hasCreds=${this.hasCredentials}`);
+    this.pushWidgetData();
+  }
+
+  private pushWidgetData(): void {
+    try {
+      const context = getContext(this) as common.UIAbilityContext;
+      WidgetPusher.refresh(context, this.courses, this.semesters,
+        this.selectedSemesterIndex, this.electricityBalance);
+    } catch (e) {
+      console.error(`pushWidgetData failed: ${e}`);
+    }
   }
 
   aboutToDisappear(): void {
@@ -546,6 +558,7 @@ struct Index {
     this.selectedSemesterIndex = 0;
     this.selectedWeekOffset = 0;
     this.statusText = '已退出登录';
+    this.pushWidgetData();
   }
 
   private async persistLoginState(): Promise<void> {
@@ -755,6 +768,7 @@ struct Index {
             this.electricityBalance = balance;
             this.saveElectricityToPref();
             this.persistLoginState();
+            this.pushWidgetData();
             this.stopPolling();
             this.showWebView = false;
             this.statusText = `电费余额: ${balance.toFixed(2)} 元`;
@@ -840,6 +854,7 @@ struct Index {
             this.electricityBalance = balance;
             this.saveElectricityToPref();
             this.persistLoginState();
+            this.pushWidgetData();
             this.stopPolling();
             this.showWebView = false;
             this.statusText = `电费余额: ${balance.toFixed(2)} 元`;
@@ -996,6 +1011,7 @@ struct Index {
     this.currentTab = 1;
     this.tabsController.changeIndex(1);
     this.tryJumpToFirstCourseWeek();
+    this.pushWidgetData();
     console.info(`handleCollectedSchedule: DONE, courses=${this.courses.length} semesters=${this.semesters.length}`);
   }
 

--- a/AoxiangAssistant/entry/src/main/ets/widget/pages/DailyCard.ets
+++ b/AoxiangAssistant/entry/src/main/ets/widget/pages/DailyCard.ets
@@ -1,0 +1,176 @@
+class CardCourse {
+  time: string = '';
+  section: string = '';
+  name: string = '';
+  loc: string = '';
+  teacher: string = '';
+  color: string = '#1E88E5';
+}
+
+class DailyData {
+  title: string = '今日课表';
+  date: string = '';
+  hint: string = '';
+  empty: boolean = true;
+  courses: CardCourse[] = [];
+}
+
+const dailyStorage = new LocalStorage();
+
+@Entry(dailyStorage)
+@Component
+struct DailyCard {
+  @LocalStorageProp('cardData') @Watch('onDataChanged') cardData: string = '';
+  @State title: string = '今日课表';
+  @State date: string = '';
+  @State hint: string = '';
+  @State empty: boolean = true;
+  @State courses: CardCourse[] = [];
+
+  aboutToAppear(): void {
+    this.parseData();
+  }
+
+  onDataChanged(propName: string): void {
+    this.parseData();
+  }
+
+  private parseData(): void {
+    const data: DailyData = new DailyData();
+    if (this.cardData.length > 0) {
+      try {
+        const obj: Record<string, Object> = JSON.parse(this.cardData) as Record<string, Object>;
+        data.title = (obj['title'] ?? '今日课表') as string;
+        data.date = (obj['date'] ?? '') as string;
+        data.hint = (obj['hint'] ?? '') as string;
+        data.empty = (obj['empty'] ?? true) === true;
+        const rawCourses: Object[] = obj['courses'] as Object[];
+        if (rawCourses !== undefined && rawCourses !== null) {
+          for (let i = 0; i < rawCourses.length; i++) {
+            const c: Record<string, Object> = rawCourses[i] as Record<string, Object>;
+            const item: CardCourse = new CardCourse();
+            item.time = (c['time'] ?? '') as string;
+            item.section = (c['section'] ?? '') as string;
+            item.name = (c['name'] ?? '') as string;
+            item.loc = (c['loc'] ?? '') as string;
+            item.teacher = (c['teacher'] ?? '') as string;
+            item.color = (c['color'] ?? '#1E88E5') as string;
+            data.courses.push(item);
+          }
+        }
+      } catch (e) {
+        console.error(`DailyCard parse error: ${e}`);
+      }
+    }
+    this.title = data.title;
+    this.date = data.date;
+    this.hint = data.hint;
+    this.empty = data.empty;
+    this.courses = data.courses;
+  }
+
+  private hasCourses(): boolean {
+    return this.courses.length > 0;
+  }
+
+  @Builder
+  CourseItem(item: CardCourse) {
+    Row() {
+      Column() {
+        Text(item.section)
+          .fontSize(10)
+          .fontColor(Color.White)
+          .fontWeight(FontWeight.Bold)
+        if (item.time.length > 0) {
+          Text(item.time)
+            .fontSize(9)
+            .fontColor(Color.White)
+            .margin({ top: 1 })
+        }
+      }
+      .alignItems(HorizontalAlign.Center)
+      .width('28%')
+
+      Column() {
+        Text(item.name)
+          .fontSize(11)
+          .fontColor(Color.White)
+          .fontWeight(FontWeight.Medium)
+          .maxLines(1)
+          .textOverflow({ overflow: TextOverflow.Ellipsis })
+        if (item.loc.length > 0) {
+          Text(item.loc)
+            .fontSize(9)
+            .fontColor(Color.White)
+            .maxLines(1)
+            .textOverflow({ overflow: TextOverflow.Ellipsis })
+            .margin({ top: 1 })
+        }
+        if (item.teacher.length > 0) {
+          Text(item.teacher)
+            .fontSize(9)
+            .fontColor(Color.White)
+            .maxLines(1)
+            .textOverflow({ overflow: TextOverflow.Ellipsis })
+            .margin({ top: 1 })
+        }
+      }
+      .alignItems(HorizontalAlign.Start)
+      .layoutWeight(1)
+      .margin({ left: 6 })
+    }
+    .width('100%')
+    .padding(6)
+    .borderRadius(6)
+    .backgroundColor(item.color)
+    .margin({ bottom: 4 })
+  }
+
+  build() {
+    Column() {
+      Row() {
+        Text(this.title)
+          .fontSize(12)
+          .fontColor(Color.White)
+          .fontWeight(FontWeight.Bold)
+        if (this.date.length > 0) {
+          Text(this.date)
+            .fontSize(10)
+            .fontColor('#FFFFFFCC')
+            .margin({ left: 6 })
+        }
+      }
+      .width('100%')
+      .justifyContent(FlexAlign.Start)
+      .margin({ bottom: 4 })
+
+      if (this.courses.length > 0) {
+        ForEach(this.courses, (item: CardCourse, idx: number) => {
+          this.CourseItem(item)
+        }, (item: CardCourse, idx: number) => `${item.section}_${item.name}_${idx}`)
+      } else {
+        Column() {
+          Text(this.hint.length > 0 ? this.hint : '今日无课')
+            .fontSize(11)
+            .fontColor(Color.White)
+            .textAlign(TextAlign.Center)
+        }
+        .width('100%')
+        .layoutWeight(1)
+        .justifyContent(FlexAlign.Center)
+        .alignItems(HorizontalAlign.Center)
+      }
+    }
+    .width('100%')
+    .height('100%')
+    .padding(10)
+    .backgroundColor('#1F1F1F')
+    .borderRadius(12)
+    .onClick(() => {
+      postCardAction(this, {
+        action: 'router',
+        abilityName: 'EntryAbility'
+      });
+    })
+  }
+}

--- a/AoxiangAssistant/entry/src/main/ets/widget/pages/ElectricityCard.ets
+++ b/AoxiangAssistant/entry/src/main/ets/widget/pages/ElectricityCard.ets
@@ -1,0 +1,92 @@
+const elecStorage = new LocalStorage();
+
+@Entry(elecStorage)
+@Component
+struct ElectricityCard {
+  @LocalStorageProp('cardData') @Watch('onDataChanged') cardData: string = '';
+  @State value: string = '--';
+  @State unit: string = '元';
+  @State empty: boolean = true;
+  @State hint: string = '打开应用查询电费';
+  @State updated: string = '';
+
+  aboutToAppear(): void {
+    this.parseData();
+  }
+
+  onDataChanged(propName: string): void {
+    this.parseData();
+  }
+
+  private parseData(): void {
+    if (this.cardData.length > 0) {
+      try {
+        const obj: Record<string, Object> = JSON.parse(this.cardData) as Record<string, Object>;
+        this.value = (obj['value'] ?? '--') as string;
+        this.unit = (obj['unit'] ?? '元') as string;
+        this.empty = (obj['empty'] ?? true) === true;
+        this.hint = (obj['hint'] ?? '打开应用查询电费') as string;
+        this.updated = (obj['updated'] ?? '') as string;
+      } catch (e) {
+        console.error(`ElectricityCard parse error: ${e}`);
+      }
+    }
+  }
+
+  build() {
+    Column() {
+      Text('电费')
+        .fontSize(12)
+        .fontColor(Color.White)
+        .fontWeight(FontWeight.Bold)
+        .width('100%')
+        .textAlign(TextAlign.Start)
+
+      if (this.empty) {
+        Column() {
+          Text(this.hint)
+            .fontSize(10)
+            .fontColor('#FFFFFFAA')
+            .textAlign(TextAlign.Center)
+        }
+        .width('100%')
+        .layoutWeight(1)
+        .justifyContent(FlexAlign.Center)
+        .alignItems(HorizontalAlign.Center)
+      } else {
+        Row() {
+          Text(this.value)
+            .fontSize(30)
+            .fontColor('#4CAF50')
+            .fontWeight(FontWeight.Bold)
+          Text(this.unit)
+            .fontSize(12)
+            .fontColor('#FFFFFFAA')
+            .margin({ left: 4 })
+        }
+        .width('100%')
+        .justifyContent(FlexAlign.Center)
+        .layoutWeight(1)
+
+        if (this.updated.length > 0) {
+          Text(`更新于 ${this.updated}`)
+            .fontSize(9)
+            .fontColor('#FFFFFF88')
+            .width('100%')
+            .textAlign(TextAlign.End)
+        }
+      }
+    }
+    .width('100%')
+    .height('100%')
+    .padding(10)
+    .backgroundColor('#1F1F1F')
+    .borderRadius(12)
+    .onClick(() => {
+      postCardAction(this, {
+        action: 'router',
+        abilityName: 'EntryAbility'
+      });
+    })
+  }
+}

--- a/AoxiangAssistant/entry/src/main/ets/widget/pages/TodayTomorrowCard.ets
+++ b/AoxiangAssistant/entry/src/main/ets/widget/pages/TodayTomorrowCard.ets
@@ -1,0 +1,198 @@
+class TTCourse {
+  time: string = '';
+  section: string = '';
+  name: string = '';
+  loc: string = '';
+  teacher: string = '';
+  color: string = '#1E88E5';
+}
+
+class TTDay {
+  label: string = '';
+  date: string = '';
+  empty: boolean = true;
+  courses: TTCourse[] = [];
+}
+
+class TTData {
+  title: string = '今明课表';
+  hint: string = '';
+  days: TTDay[] = [];
+}
+
+const ttStorage = new LocalStorage();
+
+@Entry(ttStorage)
+@Component
+struct TodayTomorrowCard {
+  @LocalStorageProp('cardData') @Watch('onDataChanged') cardData: string = '';
+  @State title: string = '今明课表';
+  @State hint: string = '';
+  @State days: TTDay[] = [];
+
+  aboutToAppear(): void {
+    this.parseData();
+  }
+
+  onDataChanged(propName: string): void {
+    this.parseData();
+  }
+
+  private parseData(): void {
+    const data: TTData = new TTData();
+    if (this.cardData.length > 0) {
+      try {
+        const obj: Record<string, Object> = JSON.parse(this.cardData) as Record<string, Object>;
+        data.title = (obj['title'] ?? '今明课表') as string;
+        data.hint = (obj['hint'] ?? '') as string;
+        const rawDays: Object[] = obj['days'] as Object[];
+        if (rawDays !== undefined && rawDays !== null) {
+          for (let di = 0; di < rawDays.length; di++) {
+            const d: Record<string, Object> = rawDays[di] as Record<string, Object>;
+            const day: TTDay = new TTDay();
+            day.label = (d['label'] ?? '') as string;
+            day.date = (d['date'] ?? '') as string;
+            day.empty = (d['empty'] ?? true) === true;
+            const rawCourses: Object[] = d['courses'] as Object[];
+            if (rawCourses !== undefined && rawCourses !== null) {
+              for (let ci = 0; ci < rawCourses.length; ci++) {
+                const c: Record<string, Object> = rawCourses[ci] as Record<string, Object>;
+                const item: TTCourse = new TTCourse();
+                item.time = (c['time'] ?? '') as string;
+                item.section = (c['section'] ?? '') as string;
+                item.name = (c['name'] ?? '') as string;
+                item.loc = (c['loc'] ?? '') as string;
+                item.teacher = (c['teacher'] ?? '') as string;
+                item.color = (c['color'] ?? '#1E88E5') as string;
+                day.courses.push(item);
+              }
+            }
+            data.days.push(day);
+          }
+        }
+      } catch (e) {
+        console.error(`TodayTomorrowCard parse error: ${e}`);
+      }
+    }
+    if (data.days.length === 0) {
+      const fallback: TTDay = new TTDay();
+      fallback.label = '今天';
+      fallback.empty = true;
+      data.days.push(fallback);
+    }
+    this.title = data.title;
+    this.hint = data.hint;
+    this.days = data.days;
+  }
+
+  @Builder
+  CourseItem(item: TTCourse) {
+    Column() {
+      Text(item.section)
+        .fontSize(8)
+        .fontColor(Color.White)
+        .fontWeight(FontWeight.Bold)
+        .maxLines(1)
+      Text(item.name)
+        .fontSize(10)
+        .fontColor(Color.White)
+        .fontWeight(FontWeight.Medium)
+        .maxLines(2)
+        .textOverflow({ overflow: TextOverflow.Ellipsis })
+        .margin({ top: 1 })
+      if (item.loc.length > 0) {
+        Text(item.loc)
+          .fontSize(8)
+          .fontColor('#FFFFFFCC')
+          .maxLines(1)
+          .textOverflow({ overflow: TextOverflow.Ellipsis })
+          .margin({ top: 1 })
+      }
+    }
+    .width('100%')
+    .padding(5)
+    .borderRadius(5)
+    .backgroundColor(item.color)
+    .alignItems(HorizontalAlign.Start)
+    .margin({ bottom: 3 })
+  }
+
+  @Builder
+  DayColumn(day: TTDay) {
+    Column() {
+      Row() {
+        Text(day.label)
+          .fontSize(10)
+          .fontColor(Color.White)
+          .fontWeight(FontWeight.Bold)
+        if (day.date.length > 0) {
+          Text(day.date)
+            .fontSize(9)
+            .fontColor('#FFFFFFCC')
+            .margin({ left: 4 })
+        }
+      }
+      .width('100%')
+      .margin({ bottom: 3 })
+
+      if (day.courses.length > 0) {
+        ForEach(day.courses, (item: TTCourse, idx: number) => {
+          this.CourseItem(item)
+        }, (item: TTCourse, idx: number) => `${item.section}_${item.name}_${idx}`)
+      } else {
+        Text('暂无课程')
+          .fontSize(10)
+          .fontColor('#FFFFFFAA')
+      }
+    }
+    .layoutWeight(1)
+    .alignItems(HorizontalAlign.Start)
+    .padding({ left: 4, right: 4 })
+    .height('100%')
+  }
+
+  build() {
+    Column() {
+      Row() {
+        Text(this.title)
+          .fontSize(12)
+          .fontColor(Color.White)
+          .fontWeight(FontWeight.Bold)
+      }
+      .width('100%')
+      .justifyContent(FlexAlign.Start)
+      .margin({ bottom: 4 })
+
+      if (this.hint.length > 0) {
+        Text(this.hint)
+          .fontSize(10)
+          .fontColor('#FFFFFFAA')
+          .textAlign(TextAlign.Center)
+          .width('100%')
+          .layoutWeight(1)
+      } else {
+        Row({
+          space: 4
+        }) {
+          ForEach(this.days, (day: TTDay, idx: number) => {
+            this.DayColumn(day)
+          }, (day: TTDay, idx: number) => `day_${idx}_${day.label}`)
+        }
+        .width('100%')
+        .layoutWeight(1)
+        .alignItems(VerticalAlign.Top)
+      }
+    }
+    .width('100%')
+    .height('100%')
+    .padding(10)
+    .backgroundColor('#1F1F1F')
+    .borderRadius(12)
+    .onClick(() => {
+      postCardAction(this, {
+        action: 'router',
+        abilityName: 'EntryAbility'
+      });
+    })
+  }
+}

--- a/AoxiangAssistant/entry/src/main/ets/widget/pages/WeeklyCard.ets
+++ b/AoxiangAssistant/entry/src/main/ets/widget/pages/WeeklyCard.ets
@@ -1,0 +1,182 @@
+class WCourse {
+  time: string = '';
+  name: string = '';
+  loc: string = '';
+  color: string = '#1E88E5';
+}
+
+class WDay {
+  label: string = '';
+  date: string = '';
+  today: boolean = false;
+  empty: boolean = true;
+  courses: WCourse[] = [];
+}
+
+class WData {
+  title: string = '每周课表';
+  hint: string = '';
+  empty: boolean = true;
+  days: WDay[] = [];
+}
+
+const weeklyStorage = new LocalStorage();
+
+@Entry(weeklyStorage)
+@Component
+struct WeeklyCard {
+  @LocalStorageProp('cardData') @Watch('onDataChanged') cardData: string = '';
+  @State title: string = '每周课表';
+  @State hint: string = '';
+  @State days: WDay[] = [];
+
+  aboutToAppear(): void {
+    this.parseData();
+  }
+
+  onDataChanged(propName: string): void {
+    this.parseData();
+  }
+
+  private parseData(): void {
+    const data: WData = new WData();
+    if (this.cardData.length > 0) {
+      try {
+        const obj: Record<string, Object> = JSON.parse(this.cardData) as Record<string, Object>;
+        data.title = (obj['title'] ?? '每周课表') as string;
+        data.hint = (obj['hint'] ?? '') as string;
+        data.empty = (obj['empty'] ?? true) === true;
+        const rawDays: Object[] = obj['days'] as Object[];
+        if (rawDays !== undefined && rawDays !== null) {
+          for (let di = 0; di < rawDays.length; di++) {
+            const d: Record<string, Object> = rawDays[di] as Record<string, Object>;
+            const day: WDay = new WDay();
+            day.label = (d['label'] ?? '') as string;
+            day.date = (d['date'] ?? '') as string;
+            day.today = (d['today'] ?? false) === true;
+            day.empty = (d['empty'] ?? true) === true;
+            const rawCourses: Object[] = d['courses'] as Object[];
+            if (rawCourses !== undefined && rawCourses !== null) {
+              for (let ci = 0; ci < rawCourses.length; ci++) {
+                const c: Record<string, Object> = rawCourses[ci] as Record<string, Object>;
+                const item: WCourse = new WCourse();
+                item.time = (c['time'] ?? '') as string;
+                item.name = (c['name'] ?? '') as string;
+                item.loc = (c['loc'] ?? '') as string;
+                item.color = (c['color'] ?? '#1E88E5') as string;
+                day.courses.push(item);
+              }
+            }
+            data.days.push(day);
+          }
+        }
+      } catch (e) {
+        console.error(`WeeklyCard parse error: ${e}`);
+      }
+    }
+    if (data.days.length === 0) {
+      const labels: string[] = ['周一', '周二', '周三', '周四', '周五', '周六', '周日'];
+      for (let i = 0; i < labels.length; i++) {
+        const day: WDay = new WDay();
+        day.label = labels[i];
+        day.empty = true;
+        data.days.push(day);
+      }
+    }
+    this.title = data.title;
+    this.hint = data.hint;
+    this.days = data.days;
+  }
+
+  @Builder
+  DayColumn(day: WDay) {
+    Column() {
+      Row() {
+        Text(day.label)
+          .fontSize(8)
+          .fontColor(day.today ? '#FFD54F' : Color.White)
+          .fontWeight(FontWeight.Bold)
+      }
+      .width('100%')
+      .justifyContent(FlexAlign.Center)
+      .margin({ bottom: 2 })
+
+      if (day.courses.length > 0) {
+        ForEach(day.courses, (item: WCourse, idx: number) => {
+          Column() {
+            Text(item.time.length > 0 ? item.time : item.name)
+              .fontSize(7)
+              .fontColor(Color.White)
+              .maxLines(1)
+              .textOverflow({ overflow: TextOverflow.Ellipsis })
+            Text(item.name)
+              .fontSize(8)
+              .fontColor(Color.White)
+              .fontWeight(FontWeight.Medium)
+              .maxLines(2)
+              .textOverflow({ overflow: TextOverflow.Ellipsis })
+              .margin({ top: 1 })
+          }
+          .width('100%')
+          .padding(3)
+          .borderRadius(4)
+          .backgroundColor(item.color)
+          .alignItems(HorizontalAlign.Start)
+          .margin({ bottom: 2 })
+        }, (item: WCourse, idx: number) => `${item.name}_${item.time}_${idx}`)
+      } else {
+        Text('')
+          .fontSize(1)
+      }
+    }
+    .layoutWeight(1)
+    .alignItems(HorizontalAlign.Center)
+    .padding({ left: 2, right: 2 })
+    .height('100%')
+  }
+
+  build() {
+    Column() {
+      Row() {
+        Text(this.title)
+          .fontSize(12)
+          .fontColor(Color.White)
+          .fontWeight(FontWeight.Bold)
+      }
+      .width('100%')
+      .justifyContent(FlexAlign.Start)
+      .margin({ bottom: 4 })
+
+      if (this.hint.length > 0) {
+        Text(this.hint)
+          .fontSize(10)
+          .fontColor('#FFFFFFAA')
+          .textAlign(TextAlign.Center)
+          .width('100%')
+          .layoutWeight(1)
+      } else {
+        Row({
+          space: 2
+        }) {
+          ForEach(this.days, (day: WDay, idx: number) => {
+            this.DayColumn(day)
+          }, (day: WDay, idx: number) => `wday_${idx}_${day.label}`)
+        }
+        .width('100%')
+        .layoutWeight(1)
+        .alignItems(VerticalAlign.Top)
+      }
+    }
+    .width('100%')
+    .height('100%')
+    .padding(8)
+    .backgroundColor('#1F1F1F')
+    .borderRadius(12)
+    .onClick(() => {
+      postCardAction(this, {
+        action: 'router',
+        abilityName: 'EntryAbility'
+      });
+    })
+  }
+}

--- a/AoxiangAssistant/entry/src/main/module.json5
+++ b/AoxiangAssistant/entry/src/main/module.json5
@@ -50,8 +50,21 @@
           {
             "name": "ohos.extension.backup",
             "resource": "$profile:backup_config"
+          },
+        ]
+      },
+      {
+        "name": "EntryFormAbility",
+        "srcEntry": "./ets/entryformability/EntryFormAbility.ets",
+        "label": "$string:EntryFormAbility_label",
+        "description": "$string:EntryFormAbility_desc",
+        "type": "form",
+        "metadata": [
+          {
+            "name": "ohos.extension.form",
+            "resource": "$profile:form_config"
           }
-        ],
+        ]
       }
     ]
   }

--- a/AoxiangAssistant/entry/src/main/resources/base/element/string.json
+++ b/AoxiangAssistant/entry/src/main/resources/base/element/string.json
@@ -11,6 +11,46 @@
     {
       "name": "EntryAbility_label",
       "value": "AoxiangAssistant"
+    },
+    {
+      "name": "EntryFormAbility_desc",
+      "value": "Aoxiang widget provider"
+    },
+    {
+      "name": "EntryFormAbility_label",
+      "value": "AoxiangAssistantWidget"
+    },
+    {
+      "name": "widget_daily_name",
+      "value": "今日课表"
+    },
+    {
+      "name": "widget_daily_desc",
+      "value": "显示今天的课程安排"
+    },
+    {
+      "name": "widget_tt_name",
+      "value": "今明课表"
+    },
+    {
+      "name": "widget_tt_desc",
+      "value": "显示今天与明天的课程安排"
+    },
+    {
+      "name": "widget_weekly_name",
+      "value": "每周课表"
+    },
+    {
+      "name": "widget_weekly_desc",
+      "value": "显示一周的课程安排"
+    },
+    {
+      "name": "widget_elec_name",
+      "value": "电费查询"
+    },
+    {
+      "name": "widget_elec_desc",
+      "value": "显示宿舍电费余额"
     }
   ]
 }

--- a/AoxiangAssistant/entry/src/main/resources/base/profile/form_config.json
+++ b/AoxiangAssistant/entry/src/main/resources/base/profile/form_config.json
@@ -1,0 +1,96 @@
+{
+  "forms": [
+    {
+      "name": "daily_card",
+      "displayName": "$string:widget_daily_name",
+      "description": "$string:widget_daily_desc",
+      "src": "./ets/widget/pages/DailyCard.ets",
+      "uiSyntax": "arkts",
+      "window": {
+        "designWidth": 720,
+        "autoDesignWidth": true
+      },
+      "isDynamic": true,
+      "isDefault": true,
+      "updateEnabled": true,
+      "scheduledUpdateTime": "07:30",
+      "updateDuration": 2,
+      "defaultDimension": "2*2",
+      "supportDimensions": [
+        "2*2"
+      ],
+      "previewImages": [
+        "$media:icon"
+      ]
+    },
+    {
+      "name": "today_tomorrow_card",
+      "displayName": "$string:widget_tt_name",
+      "description": "$string:widget_tt_desc",
+      "src": "./ets/widget/pages/TodayTomorrowCard.ets",
+      "uiSyntax": "arkts",
+      "window": {
+        "designWidth": 720,
+        "autoDesignWidth": true
+      },
+      "isDynamic": true,
+      "isDefault": false,
+      "updateEnabled": true,
+      "scheduledUpdateTime": "07:30",
+      "updateDuration": 2,
+      "defaultDimension": "2*4",
+      "supportDimensions": [
+        "2*4"
+      ],
+      "previewImages": [
+        "$media:icon"
+      ]
+    },
+    {
+      "name": "weekly_card",
+      "displayName": "$string:widget_weekly_name",
+      "description": "$string:widget_weekly_desc",
+      "src": "./ets/widget/pages/WeeklyCard.ets",
+      "uiSyntax": "arkts",
+      "window": {
+        "designWidth": 720,
+        "autoDesignWidth": true
+      },
+      "isDynamic": true,
+      "isDefault": false,
+      "updateEnabled": true,
+      "scheduledUpdateTime": "07:30",
+      "updateDuration": 2,
+      "defaultDimension": "4*4",
+      "supportDimensions": [
+        "4*4"
+      ],
+      "previewImages": [
+        "$media:icon"
+      ]
+    },
+    {
+      "name": "electricity_card",
+      "displayName": "$string:widget_elec_name",
+      "description": "$string:widget_elec_desc",
+      "src": "./ets/widget/pages/ElectricityCard.ets",
+      "uiSyntax": "arkts",
+      "window": {
+        "designWidth": 720,
+        "autoDesignWidth": true
+      },
+      "isDynamic": true,
+      "isDefault": false,
+      "updateEnabled": true,
+      "scheduledUpdateTime": "07:30",
+      "updateDuration": 2,
+      "defaultDimension": "2*2",
+      "supportDimensions": [
+        "2*2"
+      ],
+      "previewImages": [
+        "$media:icon"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- form_config.json 注册 4 张卡片：daily(2*2)、today_tomorrow(2*4)、weekly(4*4)、electricity(2*2)
- module.json5 新增 EntryFormAbility (type: form)
- WidgetDataBuilder: 预计算各卡片 JSON 快照（复用 WeekUtils/ScheduleTimes/CourseModel）
- WidgetSnapshotStore: GSKV 多进程偏好库存快照 + form 注册表
- WidgetPusher: 写快照 + formProvider.reloadAllForms 推送
- EntryFormAbility: onAddForm/onUpdateForm/onRemoveForm 按 formId 分发
- 4 个卡片页面：@LocalStorageProp('cardData') + @Watch 接收，postCardAction 跳转主界面
- Index.ets: aboutToAppear/课表导入/电费刷新/退出登录 四处挂接推送