### PR TITLE
feat: HdsTabs沉浸光感 + widget卡片深色/浅色主题跟随系统

### DIFF
--- a/AoxiangAssistant/entry/src/main/ets/pages/Index.ets
+++ b/AoxiangAssistant/entry/src/main/ets/pages/Index.ets
@@ -14,6 +14,7 @@ import { ScheduleGrid } from '../components/ScheduleGrid';
 import { Constants, LoginPhase, LoginTarget } from '../common/Constants';
 import { BusinessError } from '@kit.BasicServicesKit';
 import { WidgetPusher } from '../model/WidgetPusher';
+import { HdsTabs, HdsTabsController, hdsMaterial } from '@kit.UIDesignKit';
 
 @Entry
 @Component
@@ -64,7 +65,7 @@ struct Index {
   @StorageProp('topRectHeight') topRectHeight: number = 0;
 
   private webController: webview.WebviewController = new webview.WebviewController();
-  private tabsController: TabsController = new TabsController();
+  private tabsController: HdsTabsController = new HdsTabsController();
   private credentialStore: CredentialStore = new CredentialStore();
   private autoCollectScript: string = '';
   private apiCollectScript: string = '';
@@ -1050,45 +1051,50 @@ struct Index {
 
   build() {
     Stack() {
-      Tabs({ barPosition: BarPosition.End, controller: this.tabsController }) {
+      HdsTabs({ controller: this.tabsController }) {
         TabContent() {
           this.HomeContent()
         }
-        .tabBar('')
+        .tabBar(this.TabItem('首页', 0))
 
         TabContent() {
           this.ScheduleContent()
         }
-        .tabBar('')
+        .tabBar(this.TabItem('课表', 1))
 
         TabContent() {
           this.GradesContent()
         }
-        .tabBar('')
+        .tabBar(this.TabItem('成绩', 2))
 
         TabContent() {
           this.ManageContent()
         }
-        .tabBar('')
+        .tabBar(this.TabItem('管理', 3))
 
         TabContent() {
           this.SettingsContent()
         }
-        .tabBar('')
+        .tabBar(this.TabItem('设置', 4))
       }
       .onChange((index: number) => {
         this.currentTab = index;
       })
       .scrollable(false)
+      .vertical(false)
+      .barPosition(BarPosition.End)
+      .barOverlap(true)
+      .animationDuration(300)
+      .barFloatingStyle({
+        barBottomMargin: 28,
+        systemMaterialEffect: {
+          materialType: hdsMaterial.MaterialType.ADAPTIVE,
+          materialLevel: hdsMaterial.MaterialLevel.ADAPTIVE
+        }
+      })
       .width('100%')
       .height('100%')
       .backgroundColor($r('app.color.page_background'))
-      .barBackgroundColor(Color.Transparent)
-      .barHeight(0)
-
-      if (!this.showLoginForm && !this.showSmsForm && !this.showSemesterDialog && !this.showCourseDialog && !this.showConfirmDialog && !this.showCourseColorDialog && !this.showWebView && !this.interactiveMode) {
-        this.FloatingTabBar()
-      }
 
       if (this.showWebView) {
         this.WebViewOverlay()
@@ -1124,40 +1130,17 @@ struct Index {
   }
 
   @Builder
-  FloatingTabBar() {
-    Row() {
-      ForEach([
-        { 'label': '首页', 'index': 0 },
-        { 'label': '课表', 'index': 1 },
-        { 'label': '成绩', 'index': 2 },
-        { 'label': '管理', 'index': 3 },
-        { 'label': '设置', 'index': 4 },
-      ], (tab: Record<string, Object>) => {
-        Column() {
-          Text(tab['label'] as string)
-            .fontSize(12)
-            .fontColor(this.currentTab === (tab['index'] as number) ? $r('app.color.accent') : $r('app.color.text_hint'))
-            .fontWeight(this.currentTab === (tab['index'] as number) ? FontWeight.Bold : FontWeight.Normal)
-        }
-        .layoutWeight(1)
-        .height('100%')
-        .justifyContent(FlexAlign.Center)
-        .alignItems(HorizontalAlign.Center)
-        .onClick(() => {
-          const idx: number = tab['index'] as number;
-          this.currentTab = idx;
-          this.tabsController.changeIndex(idx);
-        })
-      }, (tab: Record<string, Object>) => `tab_${tab['index']}`)
+  TabItem(label: string, index: number) {
+    Column() {
+      Text(label)
+        .fontSize(12)
+        .fontColor(this.currentTab === index ? $r('app.color.accent') : $r('app.color.text_hint'))
+        .fontWeight(this.currentTab === index ? FontWeight.Bold : FontWeight.Normal)
     }
-    .width('92%')
-    .height(56)
-    .borderRadius(28)
-    .backgroundColor($r('app.color.tab_bar_bg'))
-    .shadow({ radius: 20, color: '#1A000000', offsetX: 0, offsetY: -2 })
-    .position({ x: '4%', y: '100%' })
-    .translate({ y: -80 })
-    .zIndex(10)
+    .width('100%')
+    .height('100%')
+    .justifyContent(FlexAlign.Center)
+    .alignItems(HorizontalAlign.Center)
   }
 
   @Builder

--- a/AoxiangAssistant/entry/src/main/ets/widget/pages/DailyCard.ets
+++ b/AoxiangAssistant/entry/src/main/ets/widget/pages/DailyCard.ets
@@ -131,12 +131,12 @@ struct DailyCard {
       Row() {
         Text(this.title)
           .fontSize(12)
-          .fontColor(Color.White)
+          .fontColor($r('app.color.text_primary'))
           .fontWeight(FontWeight.Bold)
         if (this.date.length > 0) {
           Text(this.date)
             .fontSize(10)
-            .fontColor('#FFFFFFCC')
+            .fontColor($r('app.color.text_hint'))
             .margin({ left: 6 })
         }
       }
@@ -152,7 +152,7 @@ struct DailyCard {
         Column() {
           Text(this.hint.length > 0 ? this.hint : '今日无课')
             .fontSize(11)
-            .fontColor(Color.White)
+            .fontColor($r('app.color.text_hint'))
             .textAlign(TextAlign.Center)
         }
         .width('100%')
@@ -164,7 +164,7 @@ struct DailyCard {
     .width('100%')
     .height('100%')
     .padding(10)
-    .backgroundColor('#1F1F1F')
+    .backgroundColor($r('app.color.card_background'))
     .borderRadius(12)
     .onClick(() => {
       postCardAction(this, {

--- a/AoxiangAssistant/entry/src/main/ets/widget/pages/ElectricityCard.ets
+++ b/AoxiangAssistant/entry/src/main/ets/widget/pages/ElectricityCard.ets
@@ -37,7 +37,7 @@ struct ElectricityCard {
     Column() {
       Text('电费')
         .fontSize(12)
-        .fontColor(Color.White)
+        .fontColor($r('app.color.text_primary'))
         .fontWeight(FontWeight.Bold)
         .width('100%')
         .textAlign(TextAlign.Start)
@@ -46,7 +46,7 @@ struct ElectricityCard {
         Column() {
           Text(this.hint)
             .fontSize(10)
-            .fontColor('#FFFFFFAA')
+            .fontColor($r('app.color.text_hint'))
             .textAlign(TextAlign.Center)
         }
         .width('100%')
@@ -57,11 +57,11 @@ struct ElectricityCard {
         Row() {
           Text(this.value)
             .fontSize(30)
-            .fontColor('#4CAF50')
+            .fontColor($r('app.color.balance_positive'))
             .fontWeight(FontWeight.Bold)
           Text(this.unit)
             .fontSize(12)
-            .fontColor('#FFFFFFAA')
+            .fontColor($r('app.color.text_hint'))
             .margin({ left: 4 })
         }
         .width('100%')
@@ -71,7 +71,7 @@ struct ElectricityCard {
         if (this.updated.length > 0) {
           Text(`更新于 ${this.updated}`)
             .fontSize(9)
-            .fontColor('#FFFFFF88')
+            .fontColor($r('app.color.text_hint'))
             .width('100%')
             .textAlign(TextAlign.End)
         }
@@ -80,7 +80,7 @@ struct ElectricityCard {
     .width('100%')
     .height('100%')
     .padding(10)
-    .backgroundColor('#1F1F1F')
+    .backgroundColor($r('app.color.card_background'))
     .borderRadius(12)
     .onClick(() => {
       postCardAction(this, {

--- a/AoxiangAssistant/entry/src/main/ets/widget/pages/TodayTomorrowCard.ets
+++ b/AoxiangAssistant/entry/src/main/ets/widget/pages/TodayTomorrowCard.ets
@@ -123,12 +123,12 @@ struct TodayTomorrowCard {
       Row() {
         Text(day.label)
           .fontSize(10)
-          .fontColor(Color.White)
+          .fontColor($r('app.color.text_primary'))
           .fontWeight(FontWeight.Bold)
         if (day.date.length > 0) {
           Text(day.date)
             .fontSize(9)
-            .fontColor('#FFFFFFCC')
+            .fontColor($r('app.color.text_hint'))
             .margin({ left: 4 })
         }
       }
@@ -142,7 +142,7 @@ struct TodayTomorrowCard {
       } else {
         Text('暂无课程')
           .fontSize(10)
-          .fontColor('#FFFFFFAA')
+          .fontColor($r('app.color.text_hint'))
       }
     }
     .layoutWeight(1)
@@ -156,7 +156,7 @@ struct TodayTomorrowCard {
       Row() {
         Text(this.title)
           .fontSize(12)
-          .fontColor(Color.White)
+          .fontColor($r('app.color.text_primary'))
           .fontWeight(FontWeight.Bold)
       }
       .width('100%')
@@ -166,7 +166,7 @@ struct TodayTomorrowCard {
       if (this.hint.length > 0) {
         Text(this.hint)
           .fontSize(10)
-          .fontColor('#FFFFFFAA')
+          .fontColor($r('app.color.text_hint'))
           .textAlign(TextAlign.Center)
           .width('100%')
           .layoutWeight(1)
@@ -186,7 +186,7 @@ struct TodayTomorrowCard {
     .width('100%')
     .height('100%')
     .padding(10)
-    .backgroundColor('#1F1F1F')
+    .backgroundColor($r('app.color.card_background'))
     .borderRadius(12)
     .onClick(() => {
       postCardAction(this, {

--- a/AoxiangAssistant/entry/src/main/ets/widget/pages/WeeklyCard.ets
+++ b/AoxiangAssistant/entry/src/main/ets/widget/pages/WeeklyCard.ets
@@ -94,7 +94,7 @@ struct WeeklyCard {
       Row() {
         Text(day.label)
           .fontSize(8)
-          .fontColor(day.today ? '#FFD54F' : Color.White)
+          .fontColor(day.today ? '#FFD54F' : $r('app.color.text_primary'))
           .fontWeight(FontWeight.Bold)
       }
       .width('100%')
@@ -140,7 +140,7 @@ struct WeeklyCard {
       Row() {
         Text(this.title)
           .fontSize(12)
-          .fontColor(Color.White)
+          .fontColor($r('app.color.text_primary'))
           .fontWeight(FontWeight.Bold)
       }
       .width('100%')
@@ -150,7 +150,7 @@ struct WeeklyCard {
       if (this.hint.length > 0) {
         Text(this.hint)
           .fontSize(10)
-          .fontColor('#FFFFFFAA')
+          .fontColor($r('app.color.text_hint'))
           .textAlign(TextAlign.Center)
           .width('100%')
           .layoutWeight(1)
@@ -170,7 +170,7 @@ struct WeeklyCard {
     .width('100%')
     .height('100%')
     .padding(8)
-    .backgroundColor('#1F1F1F')
+    .backgroundColor($r('app.color.card_background'))
     .borderRadius(12)
     .onClick(() => {
       postCardAction(this, {

--- a/AoxiangAssistant/entry/src/main/resources/base/element/color.json
+++ b/AoxiangAssistant/entry/src/main/resources/base/element/color.json
@@ -65,6 +65,10 @@
       "value": "#6C7B95"
     },
     {
+      "name": "balance_positive",
+      "value": "#4CAF50"
+    },
+    {
       "name": "border_light",
       "value": "#DDDDDD"
     }

--- a/AoxiangAssistant/entry/src/main/resources/dark/element/color.json
+++ b/AoxiangAssistant/entry/src/main/resources/dark/element/color.json
@@ -65,6 +65,10 @@
       "value": "#5A6A80"
     },
     {
+      "name": "balance_positive",
+      "value": "#66BB6A"
+    },
+    {
       "name": "border_light",
       "value": "#3A4555"
     }


### PR DESCRIPTION
- Index.ets: Tabs替换为HdsTabs(HdsTabsController)，barFloatingStyle开启沉浸光感材质(materialType/level=ADAPTIVE)
- 删除自定义FloatingTabBar builder及条件渲染，改用自定义TabItem builder
- 4个widget卡片页：#1F1F1F/Color.White等硬编码颜色替换为('app.color.xxx')引用
- color.json(base+dark)：新增balance_positive电量色(#4CAF50/#66BB6A)
- 验证：arkts_check通过，build_project BUILD SUCCESSFUL