### PR TITLE
Add portable backup & versioned local data contract

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,6 +9,12 @@ if (keystorePropertiesFile.exists()) {
 android { namespace "cn.nwpu.campus"; compileSdk 35
     defaultConfig { applicationId "cn.nwpu.campus"; minSdk 26; targetSdk 35; versionCode 20; versionName "2.2.2" }
 
+    sourceSets {
+        test {
+            resources.srcDir(rootProject.file("contract-fixtures"))
+        }
+    }
+
     signingConfigs {
         release {
             if (!keystoreProperties.isEmpty()) {

--- a/app/src/main/java/cn/nwpu/campus/BackgroundSyncScheduler.java
+++ b/app/src/main/java/cn/nwpu/campus/BackgroundSyncScheduler.java
@@ -19,7 +19,8 @@ final class BackgroundSyncScheduler {
 
     static void schedule(Context context, long minimumDelayMillis) {
         Context app = context.getApplicationContext();
-        SharedPreferences store = app.getSharedPreferences("campus_private", Context.MODE_PRIVATE);
+        SharedPreferences store = app.getSharedPreferences(
+                LocalDataStore.PREFERENCES_NAME, Context.MODE_PRIVATE);
         if (!hasCredentials(store)) {
             cancel(app);
             return;

--- a/app/src/main/java/cn/nwpu/campus/BackgroundSyncService.java
+++ b/app/src/main/java/cn/nwpu/campus/BackgroundSyncService.java
@@ -85,7 +85,7 @@ public class BackgroundSyncService extends Service {
 
     @Override public void onCreate() {
         super.onCreate();
-        store = getSharedPreferences("campus_private", MODE_PRIVATE);
+        store = getSharedPreferences(LocalDataStore.PREFERENCES_NAME, MODE_PRIVATE);
         createChannels();
         startForeground(SERVICE_NOTIFICATION_ID, serviceNotification("正在准备自动更新"));
         PowerManager power = (PowerManager) getSystemService(POWER_SERVICE);
@@ -362,10 +362,14 @@ public class BackgroundSyncService extends Service {
             finishAttempt(false);
             return;
         }
-        String previous = store.getString("grades", "");
         List<String> changedCourses = UpdateDiff.changedNames(
-                gradeDiffItems(previous), gradeDiffItems(updated.toString()));
-        SharedPreferences.Editor editor = store.edit().putString("grades", updated.toString());
+                gradeDiffItems(LocalDataStore.readArray(store, "grades")),
+                gradeDiffItems(updated));
+        if (!LocalDataStore.writeArray(store, "grades", updated)) {
+            finishAttempt(false);
+            return;
+        }
+        SharedPreferences.Editor editor = store.edit();
         if (!Double.isNaN(gpa)) editor.putString(PORTRAIT_GPA, Double.toString(gpa));
         editor.apply();
         ScheduleWidgetUpdater.updateAll(this);
@@ -448,8 +452,10 @@ public class BackgroundSyncService extends Service {
         if (importedCount > 0 || importedEmptySchedule) {
             List<String> changedCourses = UpdateDiff.changedNames(
                     previousItems, UpdateDiff.scheduleItems(courses));
-            ScheduleStorage.saveSemesters(store, semesters);
-            ScheduleStorage.saveCourses(store, courses);
+            if (!ScheduleStorage.saveSchedule(store, semesters, courses)) {
+                finishAttempt(false);
+                return;
+            }
             if (!firstImportedId.isEmpty()) ScheduleStorage.saveSelectedSemester(store, firstImportedId);
             ScheduleWidgetUpdater.updateAll(this);
             DataUpdateSignal.publish(this, DataUpdateSignal.TARGET_SCHEDULE);
@@ -634,10 +640,9 @@ public class BackgroundSyncService extends Service {
         return -1;
     }
 
-    private List<UpdateDiff.Item> gradeDiffItems(String raw) {
+    private List<UpdateDiff.Item> gradeDiffItems(JSONArray grades) {
         List<UpdateDiff.Item> items = new ArrayList<>();
         try {
-            JSONArray grades = new JSONArray(raw);
             for (int i = 0; i < grades.length(); i++) {
                 JSONObject grade = grades.optJSONObject(i);
                 if (grade == null) continue;

--- a/app/src/main/java/cn/nwpu/campus/BackupContract.java
+++ b/app/src/main/java/cn/nwpu/campus/BackupContract.java
@@ -1,0 +1,370 @@
+package cn.nwpu.campus;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.time.LocalDate;
+import java.time.Clock;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
+/** Stable, non-sensitive schedule backup format shared by Android and iOS. */
+public final class BackupContract {
+    public static final int LEGACY_SCHEMA_VERSION = 0;
+    public static final int CURRENT_SCHEMA_VERSION = 1;
+    public static final String FORMAT = "aoxiang-assistant.schedule-backup";
+    public static final String LEGACY_VERSION = "2.0";
+
+    public static final String KEY_FORMAT = "format";
+    public static final String KEY_SCHEMA_VERSION = "schemaVersion";
+    public static final String KEY_VERSION = "version";
+    public static final String KEY_EXPORT_DATE = "exportDate";
+    public static final String KEY_COURSES = "courses";
+    public static final String KEY_SETTINGS = "settings";
+    public static final String KEY_SEMESTERS = "semesters";
+    public static final String KEY_THEME_COLOR = "themeColor";
+    public static final String KEY_DARK_MODE = "darkMode";
+    public static final String KEY_SELECTED_SEMESTER_ID = "selectedSemesterId";
+    public static final ZoneId BUSINESS_ZONE = ZoneId.of("Asia/Shanghai");
+
+    private static final Set<String> TOP_LEVEL_KEYS = new HashSet<>(Arrays.asList(
+            KEY_FORMAT,
+            KEY_SCHEMA_VERSION,
+            KEY_VERSION,
+            KEY_EXPORT_DATE,
+            KEY_COURSES,
+            KEY_SETTINGS
+    ));
+    private static final Set<String> SETTINGS_KEYS = new HashSet<>(Arrays.asList(
+            KEY_SEMESTERS,
+            KEY_THEME_COLOR,
+            KEY_DARK_MODE,
+            KEY_SELECTED_SEMESTER_ID
+    ));
+    /** Key fragments that identify credentials or session state, regardless of nesting. */
+    private static final List<String> SENSITIVE_KEY_FRAGMENTS = Arrays.asList(
+            "password",
+            "passwd",
+            "pwd",
+            "credential",
+            "token",
+            "cookie",
+            "session",
+            "authorization",
+            "auth",
+            "secret",
+            "account",
+            "username",
+            "studentid",
+            "userid",
+            "identity",
+            "sms",
+            "captcha",
+            "verification",
+            "login"
+    );
+
+    private BackupContract() {}
+
+    public static JSONObject createDocument(List<ScheduleModels.Course> courses,
+                                            List<ScheduleModels.Semester> semesters,
+                                            String selectedSemesterId,
+                                            String themeColor,
+                                            boolean darkMode,
+                                            LocalDate exportDate) {
+        JSONArray courseArray = new JSONArray();
+        JSONArray semesterArray = new JSONArray();
+        if (courses != null) {
+            for (ScheduleModels.Course course : courses) {
+                if (course != null) courseArray.put(course.json());
+            }
+        }
+        if (semesters != null) {
+            for (ScheduleModels.Semester semester : semesters) {
+                if (semester != null) semesterArray.put(semester.json());
+            }
+        }
+        return createDocument(courseArray, semesterArray, selectedSemesterId, themeColor,
+                darkMode, exportDate);
+    }
+
+    private static JSONObject createDocument(JSONArray courses, JSONArray semesters,
+                                             String selectedSemesterId, String themeColor,
+                                             boolean darkMode, LocalDate exportDate) {
+        JSONObject backup = new JSONObject();
+        JSONObject settings = new JSONObject();
+        try {
+            settings.put(KEY_SEMESTERS, semesters == null ? new JSONArray() : copy(semesters));
+            settings.put(KEY_THEME_COLOR,
+                    themeColor == null ? ScheduleModels.DEFAULT_THEME_COLOR : themeColor);
+            settings.put(KEY_DARK_MODE, darkMode);
+            settings.put(KEY_SELECTED_SEMESTER_ID,
+                    selectedSemesterId == null ? "" : selectedSemesterId);
+            backup.put(KEY_FORMAT, FORMAT);
+            backup.put(KEY_SCHEMA_VERSION, CURRENT_SCHEMA_VERSION);
+            // Keep the old marker so v2.2.x tooling can identify the document.
+            backup.put(KEY_VERSION, LEGACY_VERSION);
+            backup.put(KEY_EXPORT_DATE, (exportDate == null ? today() : exportDate).toString());
+            backup.put(KEY_COURSES, courses == null ? new JSONArray() : copy(courses));
+            backup.put(KEY_SETTINGS, settings);
+            // Export is a security boundary: reject any secret-bearing record before
+            // the caller gets a file to write.
+            rejectSensitiveKeys(backup);
+            return backup;
+        } catch (JSONException impossible) {
+            throw new IllegalStateException("Unable to encode backup", impossible);
+        }
+    }
+
+    public static BackupData readDocument(JSONObject source) throws JSONException {
+        if (source == null) throw new JSONException("Backup is empty");
+        rejectSensitiveKeys(source);
+        rejectUnknownKeys(source, TOP_LEVEL_KEYS, "backup");
+        int schemaVersion;
+        boolean legacy;
+        if (source.has(KEY_SCHEMA_VERSION)) {
+            String format = stringValue(source, KEY_FORMAT, "");
+            if (!FORMAT.equals(format)) {
+                throw new JSONException("Unsupported backup format: " + format);
+            }
+            schemaVersion = integerValue(source, KEY_SCHEMA_VERSION, -1);
+            if (schemaVersion < CURRENT_SCHEMA_VERSION) {
+                throw new JSONException("Missing or invalid backup schemaVersion");
+            }
+            if (schemaVersion > CURRENT_SCHEMA_VERSION) {
+                throw new JSONException("Unsupported backup schemaVersion: " + schemaVersion);
+            }
+            String marker = stringValue(source, KEY_VERSION, LEGACY_VERSION);
+            if (!LEGACY_VERSION.equals(marker)) {
+                throw new JSONException("Unsupported backup version marker: " + marker);
+            }
+            legacy = false;
+        } else {
+            if (source.has(KEY_FORMAT)) {
+                throw new JSONException("Backup format marker requires schemaVersion");
+            }
+            String version = stringValue(source, KEY_VERSION, "");
+            if (!LEGACY_VERSION.equals(version)) {
+                throw new JSONException("Unsupported legacy backup version: " + version);
+            }
+            schemaVersion = LEGACY_SCHEMA_VERSION;
+            legacy = true;
+        }
+
+        JSONArray courses = source.optJSONArray(KEY_COURSES);
+        JSONObject settings = source.optJSONObject(KEY_SETTINGS);
+        if (courses == null || settings == null) {
+            throw new JSONException("Backup must contain courses and settings");
+        }
+        rejectUnknownKeys(settings, SETTINGS_KEYS, "backup settings");
+        if (!legacy && !settings.has(KEY_SEMESTERS)) {
+            throw new JSONException("Current backup must contain settings.semesters");
+        }
+        JSONArray semesters = settings.optJSONArray(KEY_SEMESTERS);
+        if (semesters == null) {
+            if (legacy && !settings.has(KEY_SEMESTERS)) {
+                semesters = new JSONArray();
+            } else {
+                throw new JSONException("Backup settings.semesters must be an array");
+            }
+        }
+        String exportDate = stringValue(source, KEY_EXPORT_DATE, "");
+        validateExportDate(exportDate);
+        String selectedSemesterId = stringValue(settings, KEY_SELECTED_SEMESTER_ID, "");
+        String themeColor = stringValue(settings, KEY_THEME_COLOR,
+                ScheduleModels.DEFAULT_THEME_COLOR);
+        boolean darkMode = booleanValue(settings, KEY_DARK_MODE, false);
+        return new BackupData(schemaVersion, legacy, exportDate,
+                copy(courses), copy(semesters), selectedSemesterId, themeColor, darkMode);
+    }
+
+    /** Validate all identifiers before an import can replace platform state. */
+    public static void validateForImport(BackupData data) throws JSONException {
+        if (data == null) throw new JSONException("Backup is empty");
+        Set<String> semesterIds = new HashSet<>();
+        for (int i = 0; i < data.semesters.length(); i++) {
+            JSONObject semester = data.semesters.optJSONObject(i);
+            if (semester == null) throw new JSONException("Backup contains an invalid semester");
+            String id = requiredString(semester, "id", "semester");
+            if (!semesterIds.add(id)) throw new JSONException("Duplicate semester id: " + id);
+        }
+        Set<String> courseIds = new HashSet<>();
+        for (int i = 0; i < data.courses.length(); i++) {
+            JSONObject course = data.courses.optJSONObject(i);
+            if (course == null) throw new JSONException("Backup contains an invalid course");
+            String id = requiredString(course, "id", "course");
+            if (!courseIds.add(id)) throw new JSONException("Duplicate course id: " + id);
+            requiredString(course, "semesterId", "course");
+            validateOptionalString(course, "assessmentMethod", "course");
+            JSONArray timeSlots = course.optJSONArray("timeSlots");
+            if (timeSlots != null) {
+                for (int j = 0; j < timeSlots.length(); j++) {
+                    JSONObject slot = timeSlots.optJSONObject(j);
+                    if (slot == null) throw new JSONException("Backup contains an invalid time slot");
+                    validateOptionalString(slot, "repeatRule", "time slot");
+                }
+            }
+        }
+        if (!data.selectedSemesterId.isEmpty() && !semesterIds.contains(data.selectedSemesterId)) {
+            throw new JSONException("Selected semester does not exist: " + data.selectedSemesterId);
+        }
+    }
+
+    private static String requiredString(JSONObject object, String key, String kind) throws JSONException {
+        if (!object.has(key) || object.isNull(key)) {
+            throw new JSONException("Missing " + kind + " " + key);
+        }
+        Object raw = object.opt(key);
+        if (!(raw instanceof String)) {
+            throw new JSONException("Non-string " + kind + " " + key);
+        }
+        String value = ((String) raw).trim();
+        if (value.isEmpty()) throw new JSONException("Empty " + kind + " " + key);
+        return value;
+    }
+
+    private static void validateOptionalString(JSONObject object, String key, String kind)
+            throws JSONException {
+        if (!object.has(key) || object.isNull(key)) return;
+        if (!(object.opt(key) instanceof String)) {
+            throw new JSONException("Non-string " + kind + " " + key);
+        }
+    }
+
+    private static String stringValue(JSONObject object, String key, String fallback)
+            throws JSONException {
+        if (!object.has(key) || object.isNull(key)) return fallback;
+        Object raw = object.opt(key);
+        if (!(raw instanceof String)) throw new JSONException("Non-string backup field: " + key);
+        return (String) raw;
+    }
+
+    private static int integerValue(JSONObject object, String key, int fallback)
+            throws JSONException {
+        if (!object.has(key) || object.isNull(key)) return fallback;
+        Object raw = object.opt(key);
+        if (!(raw instanceof Number)) throw new JSONException("Non-integer backup field: " + key);
+        double value = ((Number) raw).doubleValue();
+        if (Double.isNaN(value) || Double.isInfinite(value) || value != Math.rint(value)
+                || value < Integer.MIN_VALUE || value > Integer.MAX_VALUE) {
+            throw new JSONException("Invalid integer backup field: " + key);
+        }
+        return ((Number) raw).intValue();
+    }
+
+    private static boolean booleanValue(JSONObject object, String key, boolean fallback)
+            throws JSONException {
+        if (!object.has(key) || object.isNull(key)) return fallback;
+        Object raw = object.opt(key);
+        if (!(raw instanceof Boolean)) throw new JSONException("Non-boolean backup field: " + key);
+        return (Boolean) raw;
+    }
+
+    /** Convert legacy v2.0 documents and current documents to one canonical shape. */
+    public static JSONObject migrateToCurrent(JSONObject source) throws JSONException {
+        BackupData data = readDocument(source);
+        validateForImport(data);
+        return createDocument(data.courses, data.semesters, data.selectedSemesterId,
+                data.themeColor, data.darkMode, parseDateOrToday(data.exportDate));
+    }
+
+    private static LocalDate parseDateOrToday(String value) throws JSONException {
+        try {
+            return value == null || value.isEmpty() ? today() : LocalDate.parse(value);
+        } catch (Exception ignored) {
+            throw new JSONException("Invalid backup exportDate: " + value);
+        }
+    }
+
+    private static void validateExportDate(String value) throws JSONException {
+        if (value == null || value.isEmpty()) return;
+        parseDateOrToday(value);
+    }
+
+    private static void rejectUnknownKeys(JSONObject object, Set<String> allowed, String context)
+            throws JSONException {
+        Iterator<String> keys = object.keys();
+        while (keys.hasNext()) {
+            String key = keys.next();
+            if (!allowed.contains(key)) {
+                throw new JSONException("Unsupported " + context + " field: " + key);
+            }
+        }
+    }
+
+    private static void rejectSensitiveKeys(Object value) throws JSONException {
+        if (value instanceof JSONObject) {
+            JSONObject object = (JSONObject) value;
+            Iterator<String> keys = object.keys();
+            while (keys.hasNext()) {
+                String key = keys.next();
+                if (isSensitiveKey(key)) {
+                    throw new JSONException("Sensitive backup field is not portable: " + key);
+                }
+                Object child = object.opt(key);
+                if (child instanceof JSONObject || child instanceof JSONArray) {
+                    rejectSensitiveKeys(child);
+                }
+            }
+        } else if (value instanceof JSONArray) {
+            JSONArray array = (JSONArray) value;
+            for (int i = 0; i < array.length(); i++) {
+                Object child = array.opt(i);
+                if (child instanceof JSONObject || child instanceof JSONArray) {
+                    rejectSensitiveKeys(child);
+                }
+            }
+        }
+    }
+
+    private static boolean isSensitiveKey(String key) {
+        String normalized = key.toLowerCase(Locale.ROOT).replace("_", "").replace("-", "");
+        for (String fragment : SENSITIVE_KEY_FRAGMENTS) {
+            if (normalized.contains(fragment)) return true;
+        }
+        return false;
+    }
+
+    public static LocalDate today() {
+        return today(Clock.system(BUSINESS_ZONE));
+    }
+
+    static LocalDate today(Clock clock) {
+        return LocalDate.now(clock.withZone(BUSINESS_ZONE));
+    }
+
+    private static JSONArray copy(JSONArray value) throws JSONException {
+        return new JSONArray(value.toString());
+    }
+
+    public static final class BackupData {
+        public final int schemaVersion;
+        public final boolean legacy;
+        public final String exportDate;
+        public final JSONArray courses;
+        public final JSONArray semesters;
+        public final String selectedSemesterId;
+        public final String themeColor;
+        public final boolean darkMode;
+
+        private BackupData(int schemaVersion, boolean legacy, String exportDate, JSONArray courses,
+                           JSONArray semesters, String selectedSemesterId,
+                           String themeColor, boolean darkMode) {
+            this.schemaVersion = schemaVersion;
+            this.legacy = legacy;
+            this.exportDate = exportDate;
+            this.courses = courses;
+            this.semesters = semesters;
+            this.selectedSemesterId = selectedSemesterId;
+            this.themeColor = themeColor;
+            this.darkMode = darkMode;
+        }
+
+    }
+}

--- a/app/src/main/java/cn/nwpu/campus/BootReceiver.java
+++ b/app/src/main/java/cn/nwpu/campus/BootReceiver.java
@@ -16,7 +16,8 @@ public class BootReceiver extends BroadcastReceiver {
                 && !(Build.VERSION.SDK_INT >= 31
                     && AlarmManager.ACTION_SCHEDULE_EXACT_ALARM_PERMISSION_STATE_CHANGED.equals(action))) return;
         if (Intent.ACTION_BOOT_COMPLETED.equals(action)) {
-            boolean enabled = context.getSharedPreferences("campus_private", Context.MODE_PRIVATE)
+            boolean enabled = context.getSharedPreferences(
+                    LocalDataStore.PREFERENCES_NAME, Context.MODE_PRIVATE)
                     .getBoolean("boot_auto_start", true);
             if (!enabled) return;
         }

--- a/app/src/main/java/cn/nwpu/campus/DataUpdateSignal.java
+++ b/app/src/main/java/cn/nwpu/campus/DataUpdateSignal.java
@@ -11,7 +11,7 @@ public final class DataUpdateSignal {
     public static final String TARGET_SCHEDULE = "schedule";
     public static final String TARGET_ELECTRICITY = "electricity";
 
-    private static final String PREFERENCES = "campus_private";
+    private static final String PREFERENCES = LocalDataStore.PREFERENCES_NAME;
     private static final String REVISION_PREFIX = "data_revision_";
 
     private DataUpdateSignal() {}

--- a/app/src/main/java/cn/nwpu/campus/HomeWidgetSupport.java
+++ b/app/src/main/java/cn/nwpu/campus/HomeWidgetSupport.java
@@ -82,7 +82,8 @@ final class HomeWidgetSupport {
     }
 
     private static Summary readSummary(Context context) {
-        SharedPreferences store = context.getSharedPreferences("campus_private", Context.MODE_PRIVATE);
+        SharedPreferences store = context.getSharedPreferences(
+                LocalDataStore.PREFERENCES_NAME, Context.MODE_PRIVATE);
         DecimalFormat scoreFormat = new DecimalFormat("0.00");
         DecimalFormat gpaFormat = new DecimalFormat("0.000");
 
@@ -91,7 +92,7 @@ final class HomeWidgetSupport {
 
         List<GradeRecord> grades = new ArrayList<>();
         try {
-            JSONArray array = new JSONArray(store.getString("grades", ""));
+            JSONArray array = LocalDataStore.readArray(store, "grades");
             for (int i = 0; i < array.length(); i++) {
                 JSONObject item = array.optJSONObject(i);
                 if (item != null) grades.add(GradeRecord.from(item));
@@ -172,7 +173,8 @@ final class HomeWidgetSupport {
     }
 
     private static Theme theme(Context context) {
-        SharedPreferences store = context.getSharedPreferences("campus_private", Context.MODE_PRIVATE);
+        SharedPreferences store = context.getSharedPreferences(
+                LocalDataStore.PREFERENCES_NAME, Context.MODE_PRIVATE);
         boolean dark = ScheduleStorage.loadDarkMode(store);
         return dark
                 ? new Theme(R.drawable.widget_background_dark, 0xFFF5F8FC, 0xFF9CB0C7, 0xFF3B4654)

--- a/app/src/main/java/cn/nwpu/campus/LocalDataContract.java
+++ b/app/src/main/java/cn/nwpu/campus/LocalDataContract.java
@@ -1,0 +1,79 @@
+package cn.nwpu.campus;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Versioned JSON primitives used by local storage.
+ *
+ * <p>The first released storage shape was a bare JSON array. It remains a
+ * supported legacy input (schema 0); new writes use an object envelope so a
+ * future migration can be explicit instead of inferred from application code.
+ */
+public final class LocalDataContract {
+    public static final int LEGACY_SCHEMA_VERSION = 0;
+    public static final int CURRENT_SCHEMA_VERSION = 1;
+    public static final String KEY_SCHEMA_VERSION = "schemaVersion";
+    public static final String KEY_ITEMS = "items";
+
+    private LocalDataContract() {}
+
+    public static String encodeArray(JSONArray items) {
+        JSONObject envelope = new JSONObject();
+        try {
+            envelope.put(KEY_SCHEMA_VERSION, CURRENT_SCHEMA_VERSION);
+            envelope.put(KEY_ITEMS, items == null ? new JSONArray() : items);
+        } catch (JSONException impossible) {
+            throw new IllegalStateException("Unable to encode local data", impossible);
+        }
+        return envelope.toString();
+    }
+
+    public static DecodedArray decodeArray(String raw) throws JSONException {
+        if (raw == null || raw.trim().isEmpty()) {
+            return new DecodedArray(LEGACY_SCHEMA_VERSION, new JSONArray(), true);
+        }
+        String value = raw.trim();
+        if (value.startsWith("[")) {
+            return new DecodedArray(LEGACY_SCHEMA_VERSION, new JSONArray(value), true);
+        }
+
+        JSONObject envelope = new JSONObject(value);
+        int version = envelope.optInt(KEY_SCHEMA_VERSION, -1);
+        if (version < CURRENT_SCHEMA_VERSION) {
+            throw new JSONException("Missing or invalid local data schemaVersion");
+        }
+        if (version > CURRENT_SCHEMA_VERSION) {
+            throw new JSONException("Unsupported local data schemaVersion: " + version);
+        }
+        JSONArray items = envelope.optJSONArray(KEY_ITEMS);
+        if (items == null) {
+            throw new JSONException("Local data envelope is missing items");
+        }
+        return new DecodedArray(version, items, false);
+    }
+
+    /** True only when writing a current value cannot erase an unknown local shape. */
+    public static boolean canSafelyReplace(String raw) {
+        if (raw == null || raw.trim().isEmpty()) return true;
+        try {
+            decodeArray(raw);
+            return true;
+        } catch (JSONException ignored) {
+            return false;
+        }
+    }
+
+    public static final class DecodedArray {
+        public final int sourceVersion;
+        public final JSONArray items;
+        public final boolean legacy;
+
+        private DecodedArray(int sourceVersion, JSONArray items, boolean legacy) {
+            this.sourceVersion = sourceVersion;
+            this.items = items;
+            this.legacy = legacy;
+        }
+    }
+}

--- a/app/src/main/java/cn/nwpu/campus/LocalDataStore.java
+++ b/app/src/main/java/cn/nwpu/campus/LocalDataStore.java
@@ -1,0 +1,83 @@
+package cn.nwpu.campus;
+
+import android.content.SharedPreferences;
+
+import org.json.JSONArray;
+
+/** Android adapter for the versioned local JSON contract. */
+final class LocalDataStore {
+    static final String PREFERENCES_NAME = "campus_private";
+
+    private static final String[] ARRAY_KEYS = {
+            "grades",
+            ScheduleStorage.KEY_SEMESTERS,
+            ScheduleStorage.KEY_COURSES
+    };
+
+    private LocalDataStore() {}
+
+    static JSONArray readArray(SharedPreferences store, String key) {
+        migrateKey(store, key);
+        try {
+            LocalDataContract.DecodedArray decoded = LocalDataContract.decodeArray(
+                    store.getString(key, ""));
+            return decoded.items;
+        } catch (Exception ignored) {
+            return new JSONArray();
+        }
+    }
+
+    static boolean writeArray(SharedPreferences store, String key, JSONArray items) {
+        if (!canWriteArray(store, key)) return false;
+        store.edit()
+                .putString(key, LocalDataContract.encodeArray(items))
+                .apply();
+        return true;
+    }
+
+    static boolean writeArrays(SharedPreferences store, String firstKey, JSONArray firstItems,
+                               String secondKey, JSONArray secondItems) {
+        if (!canWriteArray(store, firstKey) || !canWriteArray(store, secondKey)) {
+            return false;
+        }
+        store.edit()
+                .putString(firstKey, LocalDataContract.encodeArray(firstItems))
+                .putString(secondKey, LocalDataContract.encodeArray(secondItems))
+                .apply();
+        return true;
+    }
+
+    static boolean canWriteArray(SharedPreferences store, String key) {
+        try {
+            return LocalDataContract.canSafelyReplace(store.getString(key, ""));
+        } catch (Exception ignored) {
+            return false;
+        }
+    }
+
+    static void ensureCurrent(SharedPreferences store) {
+        for (String key : ARRAY_KEYS) migrateKey(store, key);
+    }
+
+    private static void migrateKey(SharedPreferences store, String key) {
+        final String raw;
+        try {
+            // SharedPreferences throws when a legacy caller stored this key with
+            // a non-String type. Treat that value as opaque and leave it intact.
+            raw = store.getString(key, "");
+        } catch (Exception ignored) {
+            return;
+        }
+        if (raw == null || raw.trim().isEmpty()) return;
+        try {
+            LocalDataContract.DecodedArray decoded = LocalDataContract.decodeArray(raw);
+            if (decoded.legacy) {
+                store.edit()
+                        .putString(key, LocalDataContract.encodeArray(decoded.items))
+                        .apply();
+            }
+        } catch (Exception ignored) {
+            // Keep malformed or future-version data untouched for recovery.
+        }
+    }
+}

--- a/app/src/main/java/cn/nwpu/campus/MainActivity.java
+++ b/app/src/main/java/cn/nwpu/campus/MainActivity.java
@@ -240,7 +240,8 @@ public class MainActivity extends Activity {
     @Override
     protected void onCreate(Bundle state) {
         super.onCreate(state);
-        store = getSharedPreferences("campus_private", MODE_PRIVATE);
+        store = getSharedPreferences(LocalDataStore.PREFERENCES_NAME, MODE_PRIVATE);
+        LocalDataStore.ensureCurrent(store);
         themeColor = ScheduleStorage.loadThemeColor(store);
         darkMode = ScheduleStorage.loadDarkMode(store);
         autoCollectScript = loadAsset("auto_collect.js");
@@ -2851,10 +2852,23 @@ public class MainActivity extends Activity {
         List<String> changedCourses = UpdateDiff.changedNames(
                 gradeDiffItems(grades), gradeDiffItems(out));
         boolean wasAutomatic = automaticRun;
-        markCredentialsVerified();
+        List<GradeRecord> previousGrades = grades;
+        double previousPortraitGpa = portraitGpa;
         grades = out;
         portraitGpa = gpa;
-        saveGrades();
+        if (!saveGrades()) {
+            grades = previousGrades;
+            portraitGpa = previousPortraitGpa;
+            cancelAutomation();
+            if (initialSyncInProgress) {
+                finishInitialSyncStep("grades", false);
+            } else if (!wasAutomatic) {
+                Toast.makeText(this, "本地成绩数据版本暂不支持，未覆盖原数据", Toast.LENGTH_LONG).show();
+            }
+            recordAutomaticAttempt("grades", wasAutomatic);
+            return;
+        }
+        markCredentialsVerified();
         refreshDataPage("grades");
         cancelAutomation();
         if (initialSyncInProgress) {
@@ -2942,6 +2956,9 @@ public class MainActivity extends Activity {
             importedEmptySchedule = true;
         }
 
+        List<ScheduleModels.Semester> previousSemesters = semesters;
+        List<ScheduleModels.Course> previousCourses = courses;
+        String previousSelectedSemesterId = selectedSemesterId;
         if (importedCount == 0 && !importedEmptySchedule) {
             cancelAutomation();
             if (initialSyncInProgress) {
@@ -2961,7 +2978,19 @@ public class MainActivity extends Activity {
         List<String> changedCourses = UpdateDiff.changedNames(
                 previousItems, UpdateDiff.scheduleItems(courses));
         if (!firstImportedId.isEmpty()) selectedSemesterId = firstImportedId;
-        saveScheduleState();
+        if (!saveScheduleState()) {
+            semesters = previousSemesters;
+            courses = previousCourses;
+            selectedSemesterId = previousSelectedSemesterId;
+            cancelAutomation();
+            if (initialSyncInProgress) {
+                finishInitialSyncStep("schedule", false);
+            } else if (!wasAutomatic) {
+                Toast.makeText(this, "本地课表数据版本暂不支持，未覆盖原数据", Toast.LENGTH_LONG).show();
+            }
+            recordAutomaticAttempt("schedule", wasAutomatic);
+            return;
+        }
         scheduleShowMonth = false;
         scheduleWeekOffset = 0;
         refreshDataPage("schedule");
@@ -3191,25 +3220,14 @@ public class MainActivity extends Activity {
     }
 
     private void exportBackup() {
-        JSONObject backup = new JSONObject();
         try {
-            backup.put("version", "2.0");
-            backup.put("exportDate", LocalDate.now().toString());
-            JSONArray courseArray = new JSONArray();
-            for (ScheduleModels.Course course : courses) courseArray.put(course.json());
-            backup.put("courses", courseArray);
-            JSONObject settings = new JSONObject();
-            JSONArray semestersArray = new JSONArray();
-            for (ScheduleModels.Semester semester : semesters) semestersArray.put(semester.json());
-            settings.put("semesters", semestersArray);
-            settings.put("themeColor", themeColor);
-            settings.put("darkMode", darkMode);
-            backup.put("settings", settings);
+            JSONObject backup = BackupContract.createDocument(
+                    courses, semesters, selectedSemesterId, themeColor, darkMode, BackupContract.today());
             pendingExportJson = backup.toString(2);
             Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
             intent.addCategory(Intent.CATEGORY_OPENABLE);
             intent.setType("application/json");
-            intent.putExtra(Intent.EXTRA_TITLE, "soaring-schedule-" + LocalDate.now() + ".json");
+            intent.putExtra(Intent.EXTRA_TITLE, "soaring-schedule-" + BackupContract.today() + ".json");
             startActivityForResult(intent, REQUEST_EXPORT_JSON);
         } catch (Exception e) {
             Toast.makeText(this, "导出失败", Toast.LENGTH_SHORT).show();
@@ -3240,31 +3258,41 @@ public class MainActivity extends Activity {
             StringBuilder builder = new StringBuilder();
             String line;
             while ((line = reader.readLine()) != null) builder.append(line).append('\n');
-            JSONObject parsed = new JSONObject(builder.toString());
-            JSONArray courseArray = parsed.optJSONArray("courses");
-            JSONObject settings = parsed.optJSONObject("settings");
-            if (courseArray == null || settings == null) throw new IllegalStateException();
+            BackupContract.BackupData backup = BackupContract.readDocument(
+                    new JSONObject(builder.toString()));
+            BackupContract.validateForImport(backup);
+            if (!ScheduleStorage.canSaveSchedule(store)) throw new IllegalStateException();
 
             List<ScheduleModels.Course> importedCourses = new ArrayList<>();
-            for (int i = 0; i < courseArray.length(); i++) {
-                JSONObject item = courseArray.optJSONObject(i);
+            for (int i = 0; i < backup.courses.length(); i++) {
+                JSONObject item = backup.courses.optJSONObject(i);
                 if (item != null) importedCourses.add(ScheduleModels.Course.from(item));
             }
             List<ScheduleModels.Semester> importedSemesters = new ArrayList<>();
-            JSONArray semesterArray = settings.optJSONArray("semesters");
-            if (semesterArray != null) {
-                for (int i = 0; i < semesterArray.length(); i++) {
-                    JSONObject item = semesterArray.optJSONObject(i);
-                    if (item != null) importedSemesters.add(ScheduleModels.Semester.from(item));
-                }
+            for (int i = 0; i < backup.semesters.length(); i++) {
+                JSONObject item = backup.semesters.optJSONObject(i);
+                if (item != null) importedSemesters.add(ScheduleModels.Semester.from(item));
             }
+            List<ScheduleModels.Course> previousCourses = courses;
+            List<ScheduleModels.Semester> previousSemesters = semesters;
+            String previousThemeColor = themeColor;
+            boolean previousDarkMode = darkMode;
+            String previousSelectedSemesterId = selectedSemesterId;
             courses = importedCourses;
             semesters = importedSemesters;
             normalizeSemesterSectionTimes();
-            themeColor = settings.optString("themeColor", ScheduleModels.DEFAULT_THEME_COLOR);
-            darkMode = settings.optBoolean("darkMode", false);
+            themeColor = backup.themeColor;
+            darkMode = backup.darkMode;
+            selectedSemesterId = backup.selectedSemesterId;
             ensureSelectedSemester();
-            saveScheduleState();
+            if (!saveScheduleState()) {
+                courses = previousCourses;
+                semesters = previousSemesters;
+                themeColor = previousThemeColor;
+                darkMode = previousDarkMode;
+                selectedSemesterId = previousSelectedSemesterId;
+                throw new IllegalStateException();
+            }
             applyWindowTheme();
             showTab(TAB_SETTINGS, true);
             Toast.makeText(this, "导入成功", Toast.LENGTH_SHORT).show();
@@ -3273,21 +3301,33 @@ public class MainActivity extends Activity {
         }
     }
 
-    private void saveScheduleState() {
+    private boolean saveScheduleState() {
         ensureSelectedSemester();
-        ScheduleStorage.saveSemesters(store, semesters);
-        ScheduleStorage.saveCourses(store, courses);
+        if (!ScheduleStorage.saveSchedule(store, semesters, courses)) return false;
         ScheduleStorage.saveSelectedSemester(store, selectedSemesterId);
         ScheduleStorage.saveTheme(store, themeColor, darkMode);
         ScheduleWidgetUpdater.updateAll(this);
+        return true;
     }
 
     private boolean normalizeSemesterSectionTimes() {
         boolean changed = false;
         for (ScheduleModels.Semester semester : semesters) {
-            List<ScheduleModels.SectionTime> expected = ScheduleModels.buildDefaultSectionTimes(semester.sectionCount);
-            if (!sameSectionTimes(semester.sectionTimes, expected)) {
-                semester.sectionTimes = expected;
+            int expectedCount = Math.max(1, semester.sectionCount);
+            List<ScheduleModels.SectionTime> actual = semester.sectionTimes;
+            if (actual == null || actual.isEmpty()) {
+                semester.sectionTimes = ScheduleModels.buildDefaultSectionTimes(expectedCount);
+                changed = true;
+                continue;
+            }
+            if (actual.size() < expectedCount) {
+                List<ScheduleModels.SectionTime> defaults =
+                        ScheduleModels.buildDefaultSectionTimes(expectedCount);
+                List<ScheduleModels.SectionTime> completed = new ArrayList<>(actual);
+                for (int i = actual.size(); i < expectedCount; i++) {
+                    completed.add(defaults.get(i));
+                }
+                semester.sectionTimes = completed;
                 changed = true;
             }
         }
@@ -3324,16 +3364,6 @@ public class MainActivity extends Activity {
         } catch (Exception ignored) {
             return ScheduleUtils.mondayOnOrBefore(LocalDate.now()).toString();
         }
-    }
-
-    private boolean sameSectionTimes(List<ScheduleModels.SectionTime> first, List<ScheduleModels.SectionTime> second) {
-        if (first == null || first.size() != second.size()) return false;
-        for (int i = 0; i < first.size(); i++) {
-            ScheduleModels.SectionTime left = first.get(i);
-            ScheduleModels.SectionTime right = second.get(i);
-            if (!left.start.equals(right.start) || !left.end.equals(right.end)) return false;
-        }
-        return true;
     }
 
     private void saveTheme() {
@@ -4906,9 +4936,7 @@ public class MainActivity extends Activity {
 
     private List<GradeRecord> loadGrades() {
         try {
-            String raw = store.getString("grades", "");
-            if (raw == null || raw.isEmpty()) return new ArrayList<>();
-            JSONArray array = new JSONArray(raw);
+            JSONArray array = LocalDataStore.readArray(store, "grades");
             List<GradeRecord> out = new ArrayList<>();
             for (int i = 0; i < array.length(); i++) out.add(GradeRecord.from(array.getJSONObject(i)));
             return GradeRecord.keepHighest(out);
@@ -4917,16 +4945,19 @@ public class MainActivity extends Activity {
         }
     }
 
-    private void saveGrades() {
+    private boolean saveGrades() {
         try {
             JSONArray array = new JSONArray();
             for (GradeRecord grade : grades) array.put(grade.json());
-            SharedPreferences.Editor editor = store.edit().putString("grades", array.toString());
+            if (!LocalDataStore.writeArray(store, "grades", array)) return false;
+            SharedPreferences.Editor editor = store.edit();
             if (Double.isNaN(portraitGpa)) editor.remove(PORTRAIT_GPA);
             else editor.putString(PORTRAIT_GPA, Double.toString(portraitGpa));
             editor.apply();
             ScheduleWidgetUpdater.updateAll(this);
+            return true;
         } catch (Exception ignored) {}
+        return false;
     }
 
     private void addAutomaticUpdateControls(LinearLayout parent, String title, String target) {

--- a/app/src/main/java/cn/nwpu/campus/ScheduleModels.java
+++ b/app/src/main/java/cn/nwpu/campus/ScheduleModels.java
@@ -101,6 +101,7 @@ public final class ScheduleModels {
     public static class SectionTime {
         public String start;
         public String end;
+        private JSONObject originalJson;
 
         public SectionTime(String start, String end) {
             this.start = start;
@@ -108,7 +109,7 @@ public final class ScheduleModels {
         }
 
         public JSONObject json() {
-            JSONObject o = new JSONObject();
+            JSONObject o = copyOf(originalJson);
             try {
                 o.put("start", start);
                 o.put("end", end);
@@ -117,7 +118,10 @@ public final class ScheduleModels {
         }
 
         public static SectionTime from(JSONObject o) {
-            return new SectionTime(o.optString("start", "08:00"), o.optString("end", "08:45"));
+            SectionTime time = new SectionTime(
+                    o.optString("start", "08:00"), o.optString("end", "08:45"));
+            time.originalJson = copyOf(o);
+            return time;
         }
     }
 
@@ -128,6 +132,8 @@ public final class ScheduleModels {
         public List<Integer> classSections;
         public String teacher;
         public String location;
+        private String repeatRuleWireValue;
+        private JSONObject originalJson;
 
         public TimeSlot(String weekRange, RepeatRule repeatRule, int dayOfWeek, List<Integer> classSections) {
             this(weekRange, repeatRule, dayOfWeek, classSections, null, null);
@@ -144,10 +150,10 @@ public final class ScheduleModels {
         }
 
         public JSONObject json() {
-            JSONObject o = new JSONObject();
+            JSONObject o = copyOf(originalJson);
             try {
                 o.put("weekRange", weekRange);
-                o.put("repeatRule", repeatRule.storedValue);
+                o.put("repeatRule", repeatRuleWireValue == null ? repeatRule.storedValue : repeatRuleWireValue);
                 o.put("dayOfWeek", dayOfWeek);
                 JSONArray sections = new JSONArray();
                 for (Integer value : classSections) {
@@ -171,7 +177,7 @@ public final class ScheduleModels {
             if (sections.isEmpty()) {
                 sections.add(1);
             }
-            return new TimeSlot(
+            TimeSlot slot = new TimeSlot(
                     o.optString("weekRange", "1-17"),
                     RepeatRule.fromStoredValue(o.optString("repeatRule", "")),
                     o.optInt("dayOfWeek", 1),
@@ -179,6 +185,19 @@ public final class ScheduleModels {
                     o.isNull("teacher") ? null : o.optString("teacher", null),
                     o.isNull("location") ? null : o.optString("location", null)
             );
+            String repeatRuleValue = o.has("repeatRule") && !o.isNull("repeatRule")
+                    ? o.optString("repeatRule", "") : null;
+            // Preserve only values the current enum cannot interpret. Known values
+            // must be serialized from the mutable enum so edits are not overwritten
+            // by the original wire value.
+            slot.repeatRuleWireValue = slot.repeatRule == RepeatRule.ALL
+                    && repeatRuleValue != null
+                    && !RepeatRule.ALL.storedValue.equals(repeatRuleValue)
+                    && RepeatRule.ODD.storedValue.equals(repeatRuleValue) == false
+                    && RepeatRule.EVEN.storedValue.equals(repeatRuleValue) == false
+                    ? repeatRuleValue : null;
+            slot.originalJson = copyOf(o);
+            return slot;
         }
     }
 
@@ -190,6 +209,7 @@ public final class ScheduleModels {
         public int weekCount;
         public int sectionCount;
         public List<SectionTime> sectionTimes;
+        private JSONObject originalJson;
 
         public Semester(String id, String name, String startDate, String endDate, int weekCount, int sectionCount, List<SectionTime> sectionTimes) {
             this.id = id;
@@ -202,7 +222,7 @@ public final class ScheduleModels {
         }
 
         public JSONObject json() {
-            JSONObject o = new JSONObject();
+            JSONObject o = copyOf(originalJson);
             try {
                 o.put("id", id);
                 o.put("name", name);
@@ -220,6 +240,7 @@ public final class ScheduleModels {
         }
 
         public static Semester from(JSONObject o) {
+            String id = requireId(o, "id", "Semester");
             List<SectionTime> sectionTimes = new ArrayList<>();
             JSONArray array = o.optJSONArray("sectionTimes");
             if (array != null) {
@@ -234,8 +255,8 @@ public final class ScheduleModels {
             if (sectionTimes.isEmpty()) {
                 sectionTimes = buildDefaultSectionTimes(sectionCount);
             }
-            return new Semester(
-                    o.optString("id", "semester-default"),
+            Semester semester = new Semester(
+                    id,
                     o.optString("name", "学期"),
                     o.optString("startDate", LocalDate.now().toString()),
                     o.optString("endDate", LocalDate.now().plusWeeks(17).minusDays(1).toString()),
@@ -243,6 +264,8 @@ public final class ScheduleModels {
                     sectionCount,
                     sectionTimes
             );
+            semester.originalJson = copyOf(o);
+            return semester;
         }
     }
 
@@ -258,6 +281,8 @@ public final class ScheduleModels {
         public AssessmentMethod assessmentMethod;
         public String notes;
         public String color;
+        private String assessmentMethodWireValue;
+        private JSONObject originalJson;
 
         public Course(String id, String name, String semesterId, List<TimeSlot> timeSlots) {
             this.id = id;
@@ -267,7 +292,7 @@ public final class ScheduleModels {
         }
 
         public JSONObject json() {
-            JSONObject o = new JSONObject();
+            JSONObject o = copyOf(originalJson);
             try {
                 o.put("id", id);
                 o.put("name", name);
@@ -281,7 +306,9 @@ public final class ScheduleModels {
                 o.put("location", location == null ? JSONObject.NULL : location);
                 o.put("credits", credits == null ? JSONObject.NULL : credits);
                 o.put("teacher", teacher == null ? JSONObject.NULL : teacher);
-                o.put("assessmentMethod", assessmentMethod == null ? JSONObject.NULL : assessmentMethod.label);
+                o.put("assessmentMethod", assessmentMethod != null
+                        ? assessmentMethod.label
+                        : assessmentMethodWireValue == null ? JSONObject.NULL : assessmentMethodWireValue);
                 o.put("notes", notes == null ? JSONObject.NULL : notes);
                 o.put("color", color == null ? JSONObject.NULL : color);
             } catch (Exception ignored) {}
@@ -289,6 +316,8 @@ public final class ScheduleModels {
         }
 
         public static Course from(JSONObject o) {
+            String id = requireId(o, "id", "Course");
+            String semesterId = requireId(o, "semesterId", "Course");
             List<TimeSlot> slots = new ArrayList<>();
             JSONArray array = o.optJSONArray("timeSlots");
             if (array != null) {
@@ -303,9 +332,9 @@ public final class ScheduleModels {
                 slots.add(new TimeSlot("1-17", RepeatRule.ALL, 1, Arrays.asList(1, 2)));
             }
             Course course = new Course(
-                    o.optString("id", "course-" + System.currentTimeMillis()),
+                    id,
                     o.optString("name", "课程"),
-                    o.optString("semesterId", ""),
+                    semesterId,
                     slots
             );
             course.code = o.isNull("code") ? null : o.optString("code", null);
@@ -316,9 +345,13 @@ public final class ScheduleModels {
                 if (slot.location == null) slot.location = course.location;
                 if (slot.teacher == null) slot.teacher = course.teacher;
             }
-            course.assessmentMethod = o.isNull("assessmentMethod") ? null : AssessmentMethod.fromLabel(o.optString("assessmentMethod", ""));
+            String assessmentValue = o.isNull("assessmentMethod")
+                    ? null : o.optString("assessmentMethod", "");
+            course.assessmentMethod = assessmentValue == null ? null : AssessmentMethod.fromLabel(assessmentValue);
+            course.assessmentMethodWireValue = course.assessmentMethod == null ? assessmentValue : null;
             course.notes = o.isNull("notes") ? null : o.optString("notes", null);
             course.color = o.isNull("color") ? null : o.optString("color", null);
+            course.originalJson = copyOf(o);
             return course;
         }
 
@@ -430,5 +463,30 @@ public final class ScheduleModels {
     private static int parseMinutes(String value) {
         String[] parts = value.split(":", 2);
         return Integer.parseInt(parts[0]) * 60 + Integer.parseInt(parts[1]);
+    }
+
+    private static JSONObject copyOf(JSONObject source) {
+        if (source == null) return new JSONObject();
+        try {
+            return new JSONObject(source.toString());
+        } catch (Exception ignored) {
+            return new JSONObject();
+        }
+    }
+
+    private static String requireId(JSONObject object, String key, String kind) {
+        if (object == null || !object.has(key) || object.isNull(key)) {
+            throw new IllegalArgumentException(kind + " " + key + " must be a non-empty string");
+        }
+        Object value;
+        try {
+            value = object.get(key);
+        } catch (Exception error) {
+            throw new IllegalArgumentException(kind + " " + key + " must be a non-empty string", error);
+        }
+        if (!(value instanceof String) || ((String) value).trim().isEmpty()) {
+            throw new IllegalArgumentException(kind + " " + key + " must be a non-empty string");
+        }
+        return (String) value;
     }
 }

--- a/app/src/main/java/cn/nwpu/campus/ScheduleStorage.java
+++ b/app/src/main/java/cn/nwpu/campus/ScheduleStorage.java
@@ -20,9 +20,7 @@ public final class ScheduleStorage {
     public static List<ScheduleModels.Semester> loadSemesters(SharedPreferences store) {
         List<ScheduleModels.Semester> semesters = new ArrayList<>();
         try {
-            String raw = store.getString(KEY_SEMESTERS, "");
-            if (raw == null || raw.isEmpty()) return semesters;
-            JSONArray array = new JSONArray(raw);
+            JSONArray array = LocalDataStore.readArray(store, KEY_SEMESTERS);
             for (int i = 0; i < array.length(); i++) {
                 JSONObject item = array.optJSONObject(i);
                 if (item != null) semesters.add(ScheduleModels.Semester.from(item));
@@ -35,16 +33,14 @@ public final class ScheduleStorage {
         try {
             JSONArray array = new JSONArray();
             for (ScheduleModels.Semester semester : semesters) array.put(semester.json());
-            store.edit().putString(KEY_SEMESTERS, array.toString()).apply();
+            LocalDataStore.writeArray(store, KEY_SEMESTERS, array);
         } catch (Exception ignored) {}
     }
 
     public static List<ScheduleModels.Course> loadCourses(SharedPreferences store) {
         List<ScheduleModels.Course> courses = new ArrayList<>();
         try {
-            String raw = store.getString(KEY_COURSES, "");
-            if (raw == null || raw.isEmpty()) return courses;
-            JSONArray array = new JSONArray(raw);
+            JSONArray array = LocalDataStore.readArray(store, KEY_COURSES);
             for (int i = 0; i < array.length(); i++) {
                 JSONObject item = array.optJSONObject(i);
                 if (item != null) courses.add(ScheduleModels.Course.from(item));
@@ -57,8 +53,30 @@ public final class ScheduleStorage {
         try {
             JSONArray array = new JSONArray();
             for (ScheduleModels.Course course : courses) array.put(course.json());
-            store.edit().putString(KEY_COURSES, array.toString()).apply();
+            LocalDataStore.writeArray(store, KEY_COURSES, array);
         } catch (Exception ignored) {}
+    }
+
+    /** Save the two related collections together after both current values are verified. */
+    public static boolean saveSchedule(SharedPreferences store,
+                                       List<ScheduleModels.Semester> semesters,
+                                       List<ScheduleModels.Course> courses) {
+        try {
+            JSONArray semesterArray = new JSONArray();
+            JSONArray courseArray = new JSONArray();
+            for (ScheduleModels.Semester semester : semesters) semesterArray.put(semester.json());
+            for (ScheduleModels.Course course : courses) courseArray.put(course.json());
+            return LocalDataStore.writeArrays(store, KEY_SEMESTERS, semesterArray,
+                    KEY_COURSES, courseArray);
+        } catch (Exception ignored) {
+            return false;
+        }
+    }
+
+    /** Check that a paired schedule write cannot overwrite an unknown schema. */
+    public static boolean canSaveSchedule(SharedPreferences store) {
+        return LocalDataStore.canWriteArray(store, KEY_SEMESTERS)
+                && LocalDataStore.canWriteArray(store, KEY_COURSES);
     }
 
     public static String loadSelectedSemester(SharedPreferences store) {

--- a/app/src/main/java/cn/nwpu/campus/ScheduleWidgetData.java
+++ b/app/src/main/java/cn/nwpu/campus/ScheduleWidgetData.java
@@ -45,7 +45,8 @@ final class ScheduleWidgetData {
     static DayData forDate(LocalDate date, boolean upcomingOnly) {
         android.content.Context context = ScheduleWidgetContext.get();
         if (context == null) return new DayData(new ArrayList<>(), "假期");
-        android.content.SharedPreferences store = context.getSharedPreferences("campus_private", android.content.Context.MODE_PRIVATE);
+        android.content.SharedPreferences store = context.getSharedPreferences(
+                LocalDataStore.PREFERENCES_NAME, android.content.Context.MODE_PRIVATE);
         List<ScheduleModels.Semester> semesters = ScheduleStorage.loadSemesters(store);
         List<ScheduleModels.Course> courses = ScheduleStorage.loadCourses(store);
         ScheduleModels.Semester semester = semesterForDate(date, semesters);

--- a/app/src/main/java/cn/nwpu/campus/ScheduleWidgetProvider.java
+++ b/app/src/main/java/cn/nwpu/campus/ScheduleWidgetProvider.java
@@ -46,7 +46,8 @@ public class ScheduleWidgetProvider extends AppWidgetProvider {
         views.setRemoteAdapter(R.id.widget_course_list, service);
         views.setPendingIntentTemplate(R.id.widget_course_list, openSchedule(context));
         views.setOnClickPendingIntent(R.id.widget_root, openSchedule(context));
-        android.content.SharedPreferences store = context.getSharedPreferences("campus_private", Context.MODE_PRIVATE);
+        android.content.SharedPreferences store = context.getSharedPreferences(
+                LocalDataStore.PREFERENCES_NAME, Context.MODE_PRIVATE);
         boolean dark = ScheduleStorage.loadDarkMode(store);
         views.setInt(R.id.widget_header_divider, "setBackgroundColor", dark ? 0xFF3B4654 : 0xFFE5EDF5);
         views.setInt(R.id.widget_content_divider, "setBackgroundColor", dark ? 0xFF718096 : 0xFFB6C4D2);

--- a/app/src/main/java/cn/nwpu/campus/ScheduleWidgetService.java
+++ b/app/src/main/java/cn/nwpu/campus/ScheduleWidgetService.java
@@ -39,7 +39,8 @@ public class ScheduleWidgetService extends RemoteViewsService {
 
         private void reload() {
             ScheduleWidgetContext.set(context);
-            android.content.SharedPreferences store = context.getSharedPreferences("campus_private", android.content.Context.MODE_PRIVATE);
+            android.content.SharedPreferences store = context.getSharedPreferences(
+                    LocalDataStore.PREFERENCES_NAME, android.content.Context.MODE_PRIVATE);
             dark = ScheduleStorage.loadDarkMode(store);
             rows.clear();
             ScheduleWidgetData.DayData today = ScheduleWidgetData.forDate(LocalDate.now(), small);

--- a/app/src/test/java/cn/nwpu/campus/BackupContractTest.java
+++ b/app/src/test/java/cn/nwpu/campus/BackupContractTest.java
@@ -1,0 +1,245 @@
+package cn.nwpu.campus;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.json.JSONObject;
+import org.junit.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.time.ZoneOffset;
+
+public class BackupContractTest {
+    @Test public void createsVersionedBackupWithOnlyPortableData() throws Exception {
+        JSONObject backup = BackupContract.createDocument(
+                Collections.emptyList(), Collections.emptyList(), "", null, false,
+                LocalDate.of(2026, 1, 15));
+
+        assertEquals(BackupContract.FORMAT, backup.getString(BackupContract.KEY_FORMAT));
+        assertEquals(BackupContract.CURRENT_SCHEMA_VERSION,
+                backup.getInt(BackupContract.KEY_SCHEMA_VERSION));
+        assertEquals("2026-01-15", backup.getString(BackupContract.KEY_EXPORT_DATE));
+        assertFalse(backup.toString().contains("password"));
+        assertFalse(backup.toString().contains("cookie"));
+        assertFalse(backup.toString().contains("sms"));
+        assertFalse(backup.toString().contains("login_credentials"));
+    }
+
+    @Test public void readsLegacyV20BackupAndMarksItForMigration() throws Exception {
+        JSONObject legacy = new JSONObject()
+                .put("version", "2.0")
+                .put("exportDate", "2026-01-15")
+                .put("courses", new org.json.JSONArray())
+                .put("settings", new JSONObject()
+                        .put("semesters", new org.json.JSONArray())
+                        .put("themeColor", "#2F80ED")
+                        .put("darkMode", false));
+
+        BackupContract.BackupData data = BackupContract.readDocument(legacy);
+
+        assertTrue(data.legacy);
+        assertEquals(BackupContract.LEGACY_SCHEMA_VERSION, data.schemaVersion);
+        assertEquals("#2F80ED", data.themeColor);
+        assertEquals(BackupContract.CURRENT_SCHEMA_VERSION,
+                BackupContract.migrateToCurrent(legacy)
+                        .getInt(BackupContract.KEY_SCHEMA_VERSION));
+    }
+
+    @Test(expected = org.json.JSONException.class)
+    public void rejectsUnknownLegacyVersion() throws Exception {
+        BackupContract.readDocument(new JSONObject()
+                .put("version", "1.0")
+                .put("courses", new org.json.JSONArray())
+                .put("settings", new JSONObject()));
+    }
+
+    @Test(expected = org.json.JSONException.class)
+    public void rejectsFutureBackupSchema() throws Exception {
+        BackupContract.readDocument(new JSONObject()
+                .put("format", BackupContract.FORMAT)
+                .put("schemaVersion", 99)
+                .put("courses", new org.json.JSONArray())
+                .put("settings", new JSONObject()));
+    }
+
+    @Test(expected = org.json.JSONException.class)
+    public void rejectsStringSchemaVersionInsteadOfCoercingIt() throws Exception {
+        BackupContract.readDocument(new JSONObject()
+                .put("format", BackupContract.FORMAT)
+                .put("schemaVersion", "1")
+                .put("courses", new org.json.JSONArray())
+                .put("settings", new JSONObject().put("semesters", new org.json.JSONArray())));
+    }
+
+    @Test(expected = org.json.JSONException.class)
+    public void currentBackupRequiresTheSemestersArray() throws Exception {
+        BackupContract.readDocument(new JSONObject()
+                .put("format", BackupContract.FORMAT)
+                .put("schemaVersion", BackupContract.CURRENT_SCHEMA_VERSION)
+                .put("courses", new org.json.JSONArray())
+                .put("settings", new JSONObject()));
+    }
+
+    @Test(expected = org.json.JSONException.class)
+    public void rejectsLegacyShapeWhenItContainsCurrentFormatMarker() throws Exception {
+        BackupContract.readDocument(new JSONObject()
+                .put("format", BackupContract.FORMAT)
+                .put("version", "2.0")
+                .put("courses", new org.json.JSONArray())
+                .put("settings", new JSONObject()));
+    }
+
+    @Test public void migrationPreservesUnknownFieldsInLegacyRecords() throws Exception {
+        JSONObject legacy = new JSONObject()
+                .put("version", "2.0")
+                .put("exportDate", "2026-01-15")
+                .put("courses", new org.json.JSONArray().put(new JSONObject()
+                        .put("id", "course-fixture")
+                        .put("semesterId", "semester-fixture")
+                        .put("futureField", "must-survive")))
+                .put("settings", new JSONObject()
+                        .put("semesters", new org.json.JSONArray().put(new JSONObject()
+                                .put("id", "semester-fixture")))
+                        .put("themeColor", "#2F80ED")
+                        .put("darkMode", false));
+
+        JSONObject migrated = BackupContract.migrateToCurrent(legacy);
+
+        assertEquals("must-survive", migrated.getJSONArray("courses")
+                .getJSONObject(0).getString("futureField"));
+    }
+
+    @Test(expected = org.json.JSONException.class)
+    public void migrationRejectsRecordsThatCannotBeImportedSafely() throws Exception {
+        JSONObject legacy = new JSONObject()
+                .put("version", "2.0")
+                .put("courses", new org.json.JSONArray().put(new JSONObject()
+                        .put("id", "course-fixture")))
+                .put("settings", new JSONObject()
+                        .put("semesters", new org.json.JSONArray()));
+
+        BackupContract.migrateToCurrent(legacy);
+    }
+
+    @Test(expected = org.json.JSONException.class)
+    public void rejectsUnknownTopLevelFieldsInsteadOfDroppingThemOnMigration() throws Exception {
+        JSONObject legacy = new JSONObject()
+                .put("version", "2.0")
+                .put("courses", new org.json.JSONArray())
+                .put("settings", new JSONObject().put("semesters", new org.json.JSONArray()))
+                .put("futureTopLevelField", "must-not-be-dropped");
+
+        BackupContract.readDocument(legacy);
+    }
+
+    @Test(expected = org.json.JSONException.class)
+    public void rejectsUnknownSettingsFieldsInsteadOfDroppingThemOnMigration() throws Exception {
+        JSONObject legacy = new JSONObject()
+                .put("version", "2.0")
+                .put("courses", new org.json.JSONArray())
+                .put("settings", new JSONObject()
+                        .put("semesters", new org.json.JSONArray())
+                        .put("futureSetting", true));
+
+        BackupContract.readDocument(legacy);
+    }
+
+    @Test(expected = org.json.JSONException.class)
+    public void rejectsSensitiveKeysAnywhereInTheBackup() throws Exception {
+        JSONObject current = new JSONObject()
+                .put("format", BackupContract.FORMAT)
+                .put("schemaVersion", BackupContract.CURRENT_SCHEMA_VERSION)
+                .put("courses", new org.json.JSONArray().put(new JSONObject()
+                        .put("id", "course-fixture")
+                        .put("semesterId", "semester-fixture")
+                        .put("access_token", "must-not-be-exported")))
+                .put("settings", new JSONObject()
+                        .put("semesters", new org.json.JSONArray().put(new JSONObject()
+                                .put("id", "semester-fixture"))));
+
+        BackupContract.readDocument(current);
+    }
+
+    @Test(expected = org.json.JSONException.class)
+    public void rejectsMalformedExportDateInsteadOfRewritingItToToday() throws Exception {
+        JSONObject current = new JSONObject()
+                .put("format", BackupContract.FORMAT)
+                .put("schemaVersion", BackupContract.CURRENT_SCHEMA_VERSION)
+                .put("exportDate", "2026-99-99")
+                .put("courses", new org.json.JSONArray())
+                .put("settings", new JSONObject()
+                        .put("semesters", new org.json.JSONArray()));
+
+        BackupContract.migrateToCurrent(current);
+    }
+
+    @Test(expected = org.json.JSONException.class)
+    public void rejectsBackupImportWhenCourseIdIsMissing() throws Exception {
+        JSONObject backup = new JSONObject()
+                .put("format", BackupContract.FORMAT)
+                .put("schemaVersion", BackupContract.CURRENT_SCHEMA_VERSION)
+                .put("courses", new org.json.JSONArray().put(new JSONObject()
+                        .put("name", "课程")
+                        .put("semesterId", "semester-stable")))
+                .put("settings", new JSONObject().put("semesters", new org.json.JSONArray()));
+
+        BackupContract.validateForImport(BackupContract.readDocument(backup));
+    }
+
+    @Test(expected = org.json.JSONException.class)
+    public void rejectsNumericCourseIdInsteadOfCoercingItToAString() throws Exception {
+        JSONObject backup = new JSONObject()
+                .put("format", BackupContract.FORMAT)
+                .put("schemaVersion", BackupContract.CURRENT_SCHEMA_VERSION)
+                .put("courses", new org.json.JSONArray().put(new JSONObject()
+                        .put("id", 123)
+                        .put("name", "课程")
+                        .put("semesterId", "semester-stable")))
+                .put("settings", new JSONObject().put("semesters", new org.json.JSONArray()
+                        .put(new JSONObject().put("id", "semester-stable"))));
+
+        BackupContract.validateForImport(BackupContract.readDocument(backup));
+    }
+
+    @Test(expected = org.json.JSONException.class)
+    public void rejectsNumericEnumInsteadOfCoercingItToAString() throws Exception {
+        JSONObject backup = new JSONObject()
+                .put("format", BackupContract.FORMAT)
+                .put("schemaVersion", BackupContract.CURRENT_SCHEMA_VERSION)
+                .put("courses", new org.json.JSONArray().put(new JSONObject()
+                        .put("id", "course-stable")
+                        .put("name", "课程")
+                        .put("semesterId", "semester-stable")
+                        .put("assessmentMethod", 1)
+                        .put("timeSlots", new org.json.JSONArray().put(new JSONObject()
+                                .put("repeatRule", 1)))))
+                .put("settings", new JSONObject().put("semesters", new org.json.JSONArray()
+                        .put(new JSONObject().put("id", "semester-stable"))));
+
+        BackupContract.validateForImport(BackupContract.readDocument(backup));
+    }
+
+    @Test(expected = org.json.JSONException.class)
+    public void rejectsBackupImportWhenSelectedSemesterDoesNotExist() throws Exception {
+        JSONObject backup = new JSONObject()
+                .put("format", BackupContract.FORMAT)
+                .put("schemaVersion", BackupContract.CURRENT_SCHEMA_VERSION)
+                .put("courses", new org.json.JSONArray())
+                .put("settings", new JSONObject()
+                        .put("semesters", new org.json.JSONArray().put(new JSONObject()
+                                .put("id", "semester-stable")))
+                        .put("selectedSemesterId", "semester-missing"));
+
+        BackupContract.validateForImport(BackupContract.readDocument(backup));
+    }
+
+    @Test public void defaultExportDateUsesShanghaiBusinessCalendar() throws Exception {
+        Clock clock = Clock.fixed(Instant.parse("2025-12-31T16:30:00Z"), ZoneOffset.UTC);
+
+        assertEquals(LocalDate.of(2026, 1, 1), BackupContract.today(clock));
+    }
+}

--- a/app/src/test/java/cn/nwpu/campus/ContractFixtureTest.java
+++ b/app/src/test/java/cn/nwpu/campus/ContractFixtureTest.java
@@ -1,0 +1,65 @@
+package cn.nwpu.campus;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+
+public class ContractFixtureTest {
+    @Test public void backupFixtureIsReadableByThePortableContract() throws Exception {
+        JSONObject fixture = readJson("backup/v1/minimal_schedule_backup.json");
+        BackupContract.BackupData data = BackupContract.readDocument(fixture);
+
+        assertEquals(BackupContract.CURRENT_SCHEMA_VERSION, data.schemaVersion);
+        assertEquals(1, data.courses.length());
+        assertEquals(1, data.semesters.length());
+        assertEquals("semester-fixture-2026-spring", data.selectedSemesterId);
+        assertNoSensitiveKeys(fixture);
+    }
+
+    @Test public void localGradeFixtureUsesTheVersionedArrayEnvelope() throws Exception {
+        JSONObject fixture = readJson("local/v1/grades.json");
+        LocalDataContract.DecodedArray decoded = LocalDataContract.decodeArray(fixture.toString());
+
+        assertEquals(LocalDataContract.CURRENT_SCHEMA_VERSION, decoded.sourceVersion);
+        assertEquals(2, decoded.items.length());
+        assertEquals("课程A", decoded.items.getJSONObject(0).getString("course"));
+    }
+
+    @Test public void collectionFixtureFreezesKnownPhaseNames() throws Exception {
+        JSONObject fixture = readJson("collection/v1/phases.json");
+        JSONArray phases = fixture.getJSONArray("phases");
+
+        assertEquals(1, fixture.getInt("schemaVersion"));
+        assertTrue(phases.toString().contains("grade_api_raw"));
+        assertTrue(phases.toString().contains("schedule_data"));
+        assertTrue(phases.toString().contains("sms_required"));
+    }
+
+    private static JSONObject readJson(String path) throws Exception {
+        InputStream stream = ContractFixtureTest.class.getClassLoader().getResourceAsStream(path);
+        assertNotNull("Missing contract fixture: " + path, stream);
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+            return new JSONObject(reader.lines().collect(Collectors.joining("\n")));
+        }
+    }
+
+    private static void assertNoSensitiveKeys(JSONObject object) {
+        String raw = object.toString().toLowerCase(java.util.Locale.ROOT);
+        assertTrue(!raw.contains("password"));
+        assertTrue(!raw.contains("cookie"));
+        assertTrue(!raw.contains("sms"));
+        assertTrue(!raw.contains("token"));
+        assertTrue(!raw.contains("login_credentials"));
+    }
+}

--- a/app/src/test/java/cn/nwpu/campus/LocalDataContractTest.java
+++ b/app/src/test/java/cn/nwpu/campus/LocalDataContractTest.java
@@ -1,0 +1,51 @@
+package cn.nwpu.campus;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+
+public class LocalDataContractTest {
+    @Test public void readsLegacyBareArrayWithoutChangingItsItems() throws Exception {
+        LocalDataContract.DecodedArray decoded = LocalDataContract.decodeArray(
+                "[{\"course\":\"课程A\"}]");
+
+        assertTrue(decoded.legacy);
+        assertEquals(LocalDataContract.LEGACY_SCHEMA_VERSION, decoded.sourceVersion);
+        assertEquals("课程A", decoded.items.getJSONObject(0).getString("course"));
+    }
+
+    @Test public void writesAndReadsVersionOneEnvelope() throws Exception {
+        JSONArray items = new JSONArray().put(new JSONObject().put("value", 7));
+
+        LocalDataContract.DecodedArray decoded = LocalDataContract.decodeArray(
+                LocalDataContract.encodeArray(items));
+
+        assertFalse(decoded.legacy);
+        assertEquals(LocalDataContract.CURRENT_SCHEMA_VERSION, decoded.sourceVersion);
+        assertEquals(7, decoded.items.getJSONObject(0).getInt("value"));
+    }
+
+    @Test(expected = org.json.JSONException.class)
+    public void rejectsAnEnvelopeWithoutSchemaVersion() throws Exception {
+        LocalDataContract.decodeArray("{\"items\":[]}");
+    }
+
+    @Test(expected = org.json.JSONException.class)
+    public void rejectsAnUnknownFutureSchema() throws Exception {
+        LocalDataContract.decodeArray("{\"schemaVersion\":99,\"items\":[]}");
+    }
+
+    @Test public void permitsReplacingOnlyRecognizedArrayShapes() {
+        assertTrue(LocalDataContract.canSafelyReplace(""));
+        assertTrue(LocalDataContract.canSafelyReplace("[]"));
+        assertTrue(LocalDataContract.canSafelyReplace(
+                "{\"schemaVersion\":1,\"items\":[]}"));
+        assertFalse(LocalDataContract.canSafelyReplace(
+                "{\"schemaVersion\":99,\"items\":[]}"));
+        assertFalse(LocalDataContract.canSafelyReplace("not json"));
+    }
+}

--- a/app/src/test/java/cn/nwpu/campus/LocalDataStoreTest.java
+++ b/app/src/test/java/cn/nwpu/campus/LocalDataStoreTest.java
@@ -1,0 +1,173 @@
+package cn.nwpu.campus;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.content.SharedPreferences;
+
+import org.json.JSONArray;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class LocalDataStoreTest {
+    @Test public void readArrayFailsClosedWithoutReplacingAnUnexpectedPreferenceType() {
+        MapBackedPreferences store = new MapBackedPreferences();
+        store.values.put("grades", Boolean.TRUE);
+
+        JSONArray result = LocalDataStore.readArray(store, "grades");
+
+        assertEquals(0, result.length());
+        assertEquals(Boolean.TRUE, store.values.get("grades"));
+    }
+
+    @Test public void ensureCurrentSkipsUnexpectedTypeAndStillMigratesOtherKeys() {
+        MapBackedPreferences store = new MapBackedPreferences();
+        store.values.put("grades", Integer.valueOf(7));
+        store.values.put(ScheduleStorage.KEY_SEMESTERS, "[]");
+
+        LocalDataStore.ensureCurrent(store);
+
+        assertEquals(Integer.valueOf(7), store.values.get("grades"));
+        assertTrue(store.values.get(ScheduleStorage.KEY_SEMESTERS)
+                .toString().contains("\"schemaVersion\":1"));
+    }
+
+    @Test public void canWriteArrayRejectsUnexpectedPreferenceType() {
+        MapBackedPreferences store = new MapBackedPreferences();
+        store.values.put("grades", Collections.singleton("not-a-json-string"));
+
+        assertFalse(LocalDataStore.canWriteArray(store, "grades"));
+        assertEquals(Collections.singleton("not-a-json-string"), store.values.get("grades"));
+    }
+
+    private static final class MapBackedPreferences implements SharedPreferences {
+        private final Map<String, Object> values = new HashMap<>();
+
+        @Override public Map<String, ?> getAll() {
+            return new HashMap<>(values);
+        }
+
+        @Override public String getString(String key, String defValue) {
+            Object value = values.get(key);
+            if (value == null) return defValue;
+            if (!(value instanceof String)) throw new ClassCastException(key);
+            return (String) value;
+        }
+
+        @Override public Set<String> getStringSet(String key, Set<String> defValues) {
+            Object value = values.get(key);
+            if (value == null) return defValues;
+            if (!(value instanceof Set)) throw new ClassCastException(key);
+            @SuppressWarnings("unchecked")
+            Set<String> result = (Set<String>) value;
+            return result;
+        }
+
+        @Override public int getInt(String key, int defValue) {
+            Object value = values.get(key);
+            if (value == null) return defValue;
+            if (!(value instanceof Integer)) throw new ClassCastException(key);
+            return (Integer) value;
+        }
+
+        @Override public long getLong(String key, long defValue) {
+            Object value = values.get(key);
+            if (value == null) return defValue;
+            if (!(value instanceof Long)) throw new ClassCastException(key);
+            return (Long) value;
+        }
+
+        @Override public float getFloat(String key, float defValue) {
+            Object value = values.get(key);
+            if (value == null) return defValue;
+            if (!(value instanceof Float)) throw new ClassCastException(key);
+            return (Float) value;
+        }
+
+        @Override public boolean getBoolean(String key, boolean defValue) {
+            Object value = values.get(key);
+            if (value == null) return defValue;
+            if (!(value instanceof Boolean)) throw new ClassCastException(key);
+            return (Boolean) value;
+        }
+
+        @Override public boolean contains(String key) {
+            return values.containsKey(key);
+        }
+
+        @Override public Editor edit() {
+            return new Editor() {
+                private final Map<String, Object> pending = new HashMap<>();
+                private boolean clear;
+
+                @Override public Editor putString(String key, String value) {
+                    pending.put(key, value);
+                    return this;
+                }
+
+                @Override public Editor putStringSet(String key, Set<String> value) {
+                    pending.put(key, value);
+                    return this;
+                }
+
+                @Override public Editor putInt(String key, int value) {
+                    pending.put(key, value);
+                    return this;
+                }
+
+                @Override public Editor putLong(String key, long value) {
+                    pending.put(key, value);
+                    return this;
+                }
+
+                @Override public Editor putFloat(String key, float value) {
+                    pending.put(key, value);
+                    return this;
+                }
+
+                @Override public Editor putBoolean(String key, boolean value) {
+                    pending.put(key, value);
+                    return this;
+                }
+
+                @Override public Editor remove(String key) {
+                    pending.put(key, null);
+                    return this;
+                }
+
+                @Override public Editor clear() {
+                    clear = true;
+                    return this;
+                }
+
+                @Override public boolean commit() {
+                    applyChanges();
+                    return true;
+                }
+
+                @Override public void apply() {
+                    applyChanges();
+                }
+
+                private void applyChanges() {
+                    if (clear) values.clear();
+                    for (Map.Entry<String, Object> entry : pending.entrySet()) {
+                        if (entry.getValue() == null) values.remove(entry.getKey());
+                        else values.put(entry.getKey(), entry.getValue());
+                    }
+                }
+            };
+        }
+
+        @Override public void registerOnSharedPreferenceChangeListener(
+                OnSharedPreferenceChangeListener listener) {}
+
+        @Override public void unregisterOnSharedPreferenceChangeListener(
+                OnSharedPreferenceChangeListener listener) {}
+    }
+}

--- a/app/src/test/java/cn/nwpu/campus/ScheduleModelsTest.java
+++ b/app/src/test/java/cn/nwpu/campus/ScheduleModelsTest.java
@@ -1,10 +1,15 @@
 package cn.nwpu.campus;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.junit.Test;
 
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.List;
 
 public class ScheduleModelsTest {
@@ -47,6 +52,97 @@ public class ScheduleModelsTest {
         assertEquals(true, ScheduleModels.isFriendshipCampus("友谊校区 公字楼"));
         assertEquals(true, ScheduleModels.isFriendshipCampus("西工大友谊教学区"));
         assertEquals(false, ScheduleModels.isFriendshipCampus("长安校区 教西B座"));
+    }
+
+    @Test public void preservesUnknownRepeatRuleWhenARecordIsReadAndWritten() throws Exception {
+        JSONObject source = new JSONObject()
+                .put("weekRange", "1-17")
+                .put("repeatRule", "future-rule")
+                .put("dayOfWeek", 1)
+                .put("classSections", new JSONArray().put(1))
+                .put("futureSlotField", "keep-me");
+
+        ScheduleModels.TimeSlot slot = ScheduleModels.TimeSlot.from(source);
+
+        assertEquals("future-rule", slot.json().getString("repeatRule"));
+        assertEquals("keep-me", slot.json().getString("futureSlotField"));
+    }
+
+    @Test public void knownRepeatRuleCanBeChangedAfterReading() throws Exception {
+        JSONObject source = new JSONObject()
+                .put("weekRange", "1-17")
+                .put("repeatRule", "仅单周")
+                .put("dayOfWeek", 1)
+                .put("classSections", new JSONArray().put(1));
+
+        ScheduleModels.TimeSlot slot = ScheduleModels.TimeSlot.from(source);
+        slot.repeatRule = ScheduleModels.RepeatRule.EVEN;
+
+        assertEquals("仅双周", slot.json().getString("repeatRule"));
+    }
+
+    @Test public void preservesUnknownAssessmentMethodWhenARecordIsReadAndWritten() throws Exception {
+        JSONObject source = new JSONObject()
+                .put("id", "course-stable")
+                .put("name", "课程")
+                .put("semesterId", "semester-stable")
+                .put("assessmentMethod", "future-method")
+                .put("timeSlots", new JSONArray().put(new JSONObject()
+                        .put("weekRange", "1-17")
+                        .put("repeatRule", "")
+                        .put("dayOfWeek", 1)
+                        .put("classSections", new JSONArray().put(1))));
+
+        ScheduleModels.Course course = ScheduleModels.Course.from(source);
+
+        assertEquals("future-method", course.json().getString("assessmentMethod"));
+    }
+
+    @Test public void rejectsSemesterWithoutIdInsteadOfInventingOne() throws Exception {
+        try {
+            ScheduleModels.Semester.from(new JSONObject().put("name", "学期"));
+            fail("Expected missing semester id to be rejected");
+        } catch (IllegalArgumentException error) {
+            assertTrue(error.getMessage().contains("Semester id"));
+        }
+    }
+
+    @Test public void rejectsBlankSemesterIdInsteadOfInventingOne() throws Exception {
+        try {
+            ScheduleModels.Semester.from(new JSONObject().put("id", " \t"));
+            fail("Expected blank semester id to be rejected");
+        } catch (IllegalArgumentException error) {
+            assertTrue(error.getMessage().contains("Semester id"));
+        }
+    }
+
+    @Test public void rejectsCourseWithoutIdInsteadOfInventingOne() throws Exception {
+        try {
+            ScheduleModels.Course.from(new JSONObject().put("semesterId", "semester-stable"));
+            fail("Expected missing course id to be rejected");
+        } catch (IllegalArgumentException error) {
+            assertTrue(error.getMessage().contains("Course id"));
+        }
+    }
+
+    @Test public void rejectsCourseWithoutSemesterId() throws Exception {
+        try {
+            ScheduleModels.Course.from(new JSONObject().put("id", "course-stable"));
+            fail("Expected missing course semesterId to be rejected");
+        } catch (IllegalArgumentException error) {
+            assertTrue(error.getMessage().contains("Course semesterId"));
+        }
+    }
+
+    @Test public void rejectsBlankCourseSemesterId() throws Exception {
+        try {
+            ScheduleModels.Course.from(new JSONObject()
+                    .put("id", "course-stable")
+                    .put("semesterId", ""));
+            fail("Expected blank course semesterId to be rejected");
+        } catch (IllegalArgumentException error) {
+            assertTrue(error.getMessage().contains("Course semesterId"));
+        }
     }
 
     private static void assertTime(List<ScheduleModels.SectionTime> times, int index, String start, String end) {

--- a/contract-fixtures/backup/v1/minimal_schedule_backup.json
+++ b/contract-fixtures/backup/v1/minimal_schedule_backup.json
@@ -1,0 +1,49 @@
+{
+  "format": "aoxiang-assistant.schedule-backup",
+  "schemaVersion": 1,
+  "version": "2.0",
+  "exportDate": "2026-02-14",
+  "courses": [
+    {
+      "id": "course-fixture-linear-algebra",
+      "name": "示例课程",
+      "semesterId": "semester-fixture-2026-spring",
+      "timeSlots": [
+        {
+          "weekRange": "1-16",
+          "repeatRule": "",
+          "dayOfWeek": 1,
+          "classSections": [1, 2],
+          "teacher": "示例教师",
+          "location": "示例教学楼 A-101"
+        }
+      ],
+      "code": "FIXTURE-101",
+      "location": "示例教学楼 A-101",
+      "credits": 3.0,
+      "teacher": "示例教师",
+      "assessmentMethod": "考试",
+      "notes": null,
+      "color": "#2F80ED"
+    }
+  ],
+  "settings": {
+    "semesters": [
+      {
+        "id": "semester-fixture-2026-spring",
+        "name": "2026 春季示例学期",
+        "startDate": "2026-02-23",
+        "endDate": "2026-06-14",
+        "weekCount": 16,
+        "sectionCount": 2,
+        "sectionTimes": [
+          {"start": "08:30", "end": "09:15"},
+          {"start": "09:25", "end": "10:10"}
+        ]
+      }
+    ],
+    "themeColor": "#2F80ED",
+    "darkMode": false,
+    "selectedSemesterId": "semester-fixture-2026-spring"
+  }
+}

--- a/contract-fixtures/collection/v1/phases.json
+++ b/contract-fixtures/collection/v1/phases.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": 1,
+  "scope": "runtime-only",
+  "phases": [
+    {
+      "name": "grade_api_raw",
+      "description": "成绩接口原始响应已经可解析"
+    },
+    {
+      "name": "schedule_data",
+      "description": "课表数据已经可解析"
+    },
+    {
+      "name": "sms_required",
+      "description": "需要用户在运行时完成短信验证"
+    }
+  ]
+}

--- a/contract-fixtures/local/v1/grades.json
+++ b/contract-fixtures/local/v1/grades.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": 1,
+  "items": [
+    {
+      "course": "课程A",
+      "credits": 3.0,
+      "point": 4.0,
+      "score": 95.0,
+      "category": "课程",
+      "detail": "完全脱敏的 fixture 成绩"
+    },
+    {
+      "course": "课程B",
+      "credits": 2.0,
+      "point": null,
+      "score": null,
+      "category": "课程",
+      "detail": "无成绩示例"
+    }
+  ]
+}

--- a/docs/LOCAL_DATA_CONTRACT.md
+++ b/docs/LOCAL_DATA_CONTRACT.md
@@ -1,0 +1,204 @@
+# Local Data and Backup Contract
+
+This document freezes the portable data boundary introduced for the iOS
+refactor. It is based on Android `v2.2.2` behavior and is the source of truth
+for new Android and iOS writers. It covers data that may be migrated between
+app versions or exported by the user; it does not turn platform credentials or
+web sessions into portable data.
+
+The canonical, fully fictional test inputs are under
+[`contract-fixtures/`](../contract-fixtures/). They are shared test assets, not
+sample user records.
+
+## Compatibility Rules
+
+All JSON is UTF-8. Object member order is insignificant. Readers must preserve
+an original value when its schema is unknown or invalid; they must never
+replace it with an empty collection as a side effect of a failed read.
+
+| Data | Legacy input | Current write shape | Migration rule |
+| --- | --- | --- | --- |
+| Local JSON collections | Bare array (schema `0`) | `{"schemaVersion": 1, "items": [...]}` | Decode the array, then write schema `1` only after successful decoding. |
+| Schedule backup | `version: "2.0"`, with `courses` and `settings` and no `format`/`schemaVersion` | `format: "aoxiang-assistant.schedule-backup"`, `schemaVersion: 1`, plus the compatible `version: "2.0"` marker | Validate the legacy document, materialize the canonical in-memory form, then write schema `1` on the next export. |
+
+`schemaVersion` is an integer. Version `0` is reserved for the legacy local
+bare-array shape, and version `1` is the current shape. A reader that sees a
+version greater than its supported version must fail closed and leave the
+stored bytes untouched. It must not silently downgrade, erase, or rewrite the
+value. Missing or malformed schema markers are invalid except for the
+explicitly defined legacy forms above.
+
+## Local Collections
+
+The Android preferences namespace is `campus_private`. Its versioned JSON
+collection keys are `grades`, `schedule_semesters`, and `schedule_courses`.
+The key name is an Android implementation detail; the envelope and item JSON
+are the cross-platform contract.
+
+```json
+{
+  "schemaVersion": 1,
+  "items": []
+}
+```
+
+An absent or empty local value means an empty legacy collection. New writers
+always emit the envelope. The iOS implementation may use an Application
+Support file or `UserDefaults`, but it must retain this JSON representation and
+the unsupported-schema protection above.
+
+### Grade Item
+
+`grades.items[]` uses the existing `GradeRecord` wire shape:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `course` | string | Display course name. |
+| `credits` | number | May be `0`. |
+| `point` | number or `null` | Grade point. |
+| `score` | number or `null` | Numeric score. |
+| `category` | string | Defaults to `"课程"` in the Android reader. |
+| `detail` | string | Sanitized display detail; not an authentication field. |
+
+Grades are local, non-secret user data, but are deliberately outside the
+portable schedule backup in version `1`.
+
+### Schedule Item Types
+
+`schedule_semesters.items[]` uses:
+
+| Field | Type |
+| --- | --- |
+| `id`, `name`, `startDate`, `endDate` | string |
+| `weekCount`, `sectionCount` | integer |
+| `sectionTimes` | array of `{ "start": "HH:mm", "end": "HH:mm" }` |
+
+`schedule_courses.items[]` uses:
+
+| Field | Type |
+| --- | --- |
+| `id`, `name`, `semesterId` | string |
+| `timeSlots` | array of time-slot objects |
+| `code`, `location`, `teacher`, `notes`, `color` | string or `null` |
+| `credits` | number or `null` |
+| `assessmentMethod` | enum string or `null` |
+
+A time-slot object has `weekRange` (string), `repeatRule` (enum string),
+`dayOfWeek` (integer `1` through `7`), `classSections` (integer array), and
+`teacher` and `location` (string or `null`).
+
+## Backup Document
+
+The current portable backup is a JSON object with this top-level shape:
+
+```json
+{
+  "format": "aoxiang-assistant.schedule-backup",
+  "schemaVersion": 1,
+  "version": "2.0",
+  "exportDate": "YYYY-MM-DD",
+  "courses": [],
+  "settings": {
+    "semesters": [],
+    "themeColor": "#2F80ED",
+    "darkMode": false,
+    "selectedSemesterId": ""
+  }
+}
+```
+
+`courses` contains the course item type above. `settings.semesters` contains
+the semester item type above. `selectedSemesterId` is an empty string when no
+semester is selected; otherwise it is the exact opaque `id` of an entry in
+`settings.semesters`. `themeColor` is a color string, and `darkMode` is a
+boolean. Importers must require `courses` and `settings`; an absent
+`settings.semesters` in a legacy `2.0` document is treated as an empty array.
+
+The `version: "2.0"` member remains present so existing v2.2.x tooling can
+identify the document. New code must use `format` and `schemaVersion` to make
+compatibility decisions, not infer a version from optional payload fields.
+
+The backup has a deliberately narrow scope. It includes only schedule courses,
+semesters, theme color, dark-mode preference, selected semester, and the
+export calendar date. It excludes grades, GPA, electricity readings,
+auto-update settings and scheduling state, data revision counters, user
+identity, and every authentication or session value.
+
+## Wire Values, Dates, and IDs
+
+Use these exact values on every writer:
+
+| Value | Allowed wire values |
+| --- | --- |
+| `repeatRule` | `""` (all weeks), `"仅单周"`, `"仅双周"` |
+| `assessmentMethod` | `"考试"`, `"考察"`, `"PnP"`, or JSON `null` |
+| Calendar date | `YYYY-MM-DD` |
+| Section time | `HH:mm`, 24-hour, zero-padded |
+| Runtime timestamp | Unix epoch milliseconds as a JSON number when a runtime-only record needs one |
+
+Business calendar calculations use `Asia/Shanghai`. A date-only value is a
+calendar date in that business timezone, not an instant, and must not be
+shifted when imported on a device with another timezone. New platform code
+must generate dates using this timezone explicitly.
+
+Course IDs and semester IDs are opaque stable strings. They have no prescribed
+format, must be exported/imported byte-for-byte, and must not be parsed for
+meaning or regenerated during a migration. New records must receive an ID
+before they are persisted.
+
+Android v2.2.2 maps an unrecognized `repeatRule` to `""` and an unrecognized
+`assessmentMethod` to `null`; that legacy parser behavior is not a safe
+round-trip guarantee. For the iOS migration, an unknown enum in a
+read-modify-write transaction is a validation failure: retain the original raw
+record and do not serialize an inferred fallback. Unknown object members must
+also survive a cross-version round-trip, either by retaining the raw JSON or by
+rejecting the write without replacing stored data.
+
+The Android contract implementation retains unknown members inside course,
+semester, section-time, and time-slot records. It cannot retain unknown
+members added to the backup envelope or `settings`, so those members are
+rejected before import or migration rather than silently dropped. A migration
+also runs the complete identifier validation before writing schema `1`.
+`exportDate`, when present, must be a valid `YYYY-MM-DD` calendar date; invalid
+dates are rejected rather than replaced with the current date.
+
+## Security and Platform Boundaries
+
+Portable backups are user-shareable files. They must never contain passwords,
+account names, encrypted credential blobs, bearer tokens, WebView cookies,
+SMS verification codes, or authentication/synchronization state. A fixture
+must never contain those values either.
+
+| Boundary | Android | iOS | Backup rule |
+| --- | --- | --- |
+| Credentials | Android Keystore-protected `login_credentials` blob | Keychain item | Never export or import. |
+| Web session | `CookieManager` cookie store | `WKWebsiteDataStore` cookie/data store | Never export or import. |
+| SMS verification code | Runtime-only input | Runtime-only input | Never persist in the contract or export. |
+| Scheduled sync/auth state | Private preference/runtime state | Private app/runtime state | Never export; rebuilding it requires a new platform session. |
+| Widget data | Non-sensitive display snapshot only | App Group non-sensitive display snapshot only | A widget must not receive credentials or session state. |
+
+Importing a backup must not clear, restore, or validate credentials and must
+not mutate the WebView cookie store. It updates only the backup fields after
+the entire document has been validated.
+
+Readers recursively reject field names that identify credentials or session
+state, including `password`, `credential`, `token`, `cookie`, `auth`, `account`,
+`studentId`, `sms`, `captcha`, and `login` variants. This check applies to
+unknown record members as well as the fixed envelope, so a future field cannot
+accidentally turn a portable backup into a secret-bearing export.
+
+## Fixture and Test Contract
+
+The fixtures are intentionally small and are loaded as test resources from the
+repository-root `contract-fixtures` directory:
+
+| Fixture | Purpose |
+| --- | --- |
+| `backup/v1/minimal_schedule_backup.json` | Current minimal portable backup with one fictional course and semester. |
+| `local/v1/grades.json` | Current versioned grade collection with two fictional records. |
+| `collection/v1/phases.json` | Runtime-only collection phase names; it is not backup payload data. |
+
+Android's `ContractFixtureTest` checks that these resources are on the unit
+test classpath and that the backup fixture contains none of the prohibited
+sensitive-key strings. A Swift test target should load the same files directly
+from the repository and validate the same schema and safety properties.

--- a/findings.md
+++ b/findings.md
@@ -1,0 +1,41 @@
+# Findings
+
+## Baseline
+
+- 当前分支起点为 `main` 的 `v2.2.2`，Android 单模块 Java 项目。
+- CodeGraph 索引：85 files、1,451 nodes、4,577 edges，索引健康。
+- `MainActivity.java` 5,218 行，承担 UI、WebView 采集、认证、存储、通知、后台调度、备份和更新检查。
+- `BackgroundSyncService.java` 816 行，另有一套 WebView 轮询和 phase dispatch。
+
+## Existing backup (v2.2.2)
+
+`MainActivity.exportBackup` 生成：
+
+- `version: "2.0"`
+- `exportDate: YYYY-MM-DD`
+- `courses: Course[]`
+- `settings.semesters: Semester[]`
+- `settings.themeColor: String`
+- `settings.darkMode: Boolean`
+
+它不包含成绩、GPA、电费、自动更新状态、同步时间、认证凭据、WebView Cookie 或短信验证码。导入要求 `courses` 和 `settings`，缺少 `settings.semesters` 时按空列表处理。
+
+## Existing local storage
+
+- SharedPreferences 文件名：`campus_private`
+- `grades`、`schedule_semesters`、`schedule_courses` 是裸 JSON 数组。
+- 选中学期、主题和深色模式是独立 key。
+- `login_credentials` 是 Android Keystore AES-GCM 密文；Cookie 在 WebView CookieManager 中，不属于 JSON 数据。
+- Widget、Activity 和后台服务都直接消费 SharedPreferences，因此迁移必须覆盖所有消费者。
+
+## Stable wire values to preserve
+
+- `RepeatRule`: `""`、`"仅单周"`、`"仅双周"`
+- `AssessmentMethod`: `"考试"`、`"考察"`、`"PnP"` 或 JSON null
+- 日期：ISO-8601 calendar date `YYYY-MM-DD`
+- 时间：24 小时制 `HH:mm`
+- 课程/学期 ID：不透明字符串，导入导出原样保留；新写入必须显式携带
+
+## Security boundary
+
+普通备份可被用户分享，不能包含密码、账号密文、Cookie、认证 token、短信验证码、学生唯一身份信息或同步调度内部状态。凭据留在 Android Keystore / iOS Keychain；会话留在各平台 WebView cookie store；Widget 只读脱敏数据快照。

--- a/progress.md
+++ b/progress.md
@@ -1,0 +1,9 @@
+# Progress
+
+## 2026-09-04
+
+- 创建 `iOS` 分支和本阶段 goal。
+- 读取并启用 `planning-with-files`、`tdd`、`project-architect` 技能。
+- 完成 CodeGraph/源码盘点，记录在 `findings.md`。
+- 已新增 `LocalDataContract`、`LocalDataStore`、`BackupContract` 初版，并接入部分 Activity/课表存储路径。
+- 已发现并待修复：后台服务和 Widget 的成绩读取、旧备份识别、契约文档/fixture/测试、编译验证。

--- a/task_plan.md
+++ b/task_plan.md
@@ -1,0 +1,35 @@
+# iOS 第一阶段计划
+
+## Goal
+
+在 `iOS` 分支冻结翱翔助手 v2.2.2 的本地数据与备份契约，提供可迁移的 schemaVersion、兼容旧数据的迁移入口、脱敏跨平台 fixture 和测试入口；不改变现有 Android 用户可见行为，也不把凭据或 WebView 会话放入备份。
+
+## Phases
+
+- [x] Phase 1: 盘点 v2.2.2 的存储、备份字段和安全边界
+- [ ] Phase 2: 接入版本化本地数组与备份 envelope，保留旧格式读取
+- [ ] Phase 3: 写契约文档、跨平台 fixture 和 seam 测试
+- [ ] Phase 4: 编译、测试、静态审计并完成目标逐项验收
+
+## Decisions
+
+- 新本地数组 envelope 使用 `schemaVersion: 1` 和 `items`；旧裸数组视为 schema 0，只读时迁移。
+- 备份使用 `format: aoxiang-assistant.schedule-backup`、`schemaVersion: 1`；旧 `version: 2.0` 文档继续可读。
+- 备份只覆盖课程、学期和主题/深色/选中学期设置；成绩、GPA、电费、同步状态、自动更新设置、凭据、Cookie 和短信验证码不在备份范围内。
+- 日期使用 `YYYY-MM-DD`，节次时间使用 `HH:mm`，持久化时间戳使用 Unix epoch milliseconds；身份认证和会话由平台安全存储管理。
+- 先测试纯 JSON contract seam，再接入 Android 存储适配器；不在本阶段重写 Activity 或 WebView。
+
+## Errors Encountered
+
+| Error | Attempt | Resolution |
+|---|---:|---|
+| Gradle wrapper download timeout | Earlier baseline | Record as verification gap; retry with available local cache or report network limitation, never claim green tests without output. |
+
+## Verification Gates
+
+- [ ] 旧 v2.2.2 裸数组可被读取并写成 schema 1 envelope
+- [ ] 旧 `version: 2.0` 备份可导入，新备份含 `format` 与 `schemaVersion`
+- [ ] 未来 schema 会拒绝且不覆盖原始数据
+- [ ] fixture 不含账号、密码、Cookie、验证码或真实个人信息
+- [ ] Android 所有成绩/课表消费者使用同一契约读写
+- [ ] JUnit、编译和 lint 结果已记录


### PR DESCRIPTION
Introduce a portable, versioned backup and local-storage contract and adapters. Adds BackupContract (portable schedule backup format), LocalDataContract (versioned array envelope) and LocalDataStore (SharedPreferences adapter) and switches consumers to use them. Make schedule writes atomic (saveSchedule) and add safe-write/migration checks to avoid overwriting unknown schemas. Update ScheduleModels to preserve unknown JSON fields and wire values and validate required IDs. Wire test fixtures, unit tests, and documentation (contract-fixtures/, docs/LOCAL_DATA_CONTRACT.md, multiple *Test.java files). Also update build.gradle to include contract-fixtures on the test classpath and replace literal preference name usages with LocalDataStore.PREFERENCES_NAME. These changes enforce cross-platform portability and reject sensitive fields during export/import.